### PR TITLE
Cwdoe 1369 drag drop reorder datafields

### DIFF
--- a/src/app/components/data-field-edit-dialog/data-field-edit-dialog.component.html
+++ b/src/app/components/data-field-edit-dialog/data-field-edit-dialog.component.html
@@ -64,7 +64,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
         </mat-checkbox><br />
       </div>
       <div class="data-options" *ngIf="data.dataField.isChosenFromList">
-        <div class="data-option" *ngFor="let dataOption of sortedDataFieldOptions()">
+        <div class="data-option" *ngFor="let dataOption of data.dataField.dataOptions">
           <div *ngIf="(data.isContentDeveloper || data.isOwner) && !optionListNotAllowed()">
             <button
               mat-icon-button

--- a/src/app/components/data-field-list/data-field-list.component.html
+++ b/src/app/components/data-field-list/data-field-list.component.html
@@ -77,14 +77,14 @@ project root for license information or contact permission@sei.cmu.edu for full 
           <mat-header-cell *matHeaderCellDef class="mat-column-draghandle"></mat-header-cell>
           <mat-cell *matCellDef="let element;" class="mat-column-draghandle">
             <div class="draghandle-div">
-              <mat-icon cdkDragHandle class="mdi-18px down-12" fontIcon="mdi-drag-vertical"/>
+              <mat-icon cdkDragHandle cdkDragRootElement="mat-row" cdkDrag [cdkDragData]="element" cdkDragLockAxis="y" [cdkDragPreviewClass]="userTheme" class="mdi-18px down-12" fontIcon="mdi-drag-vertical"/>
             </div>
           </mat-cell>
         </ng-container>
         <ng-container matColumnDef="draghandleSpacer">
           <mat-header-cell *matHeaderCellDef class="mat-column-draghandle"></mat-header-cell>
           <mat-cell *matCellDef="let element;" class="mat-column-draghandle">
-            <span></span>
+            <div class="draghandle-div"></div>
           </mat-cell>
         </ng-container>
         <!-- action column -->
@@ -201,7 +201,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
         <!-- row definitions -->
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
         <mat-row *matRowDef="let row; columns: systemFieldDisplayedColumns when: fieldIsSystemDefined"></mat-row>
-        <mat-row *matRowDef="let row; columns: displayedColumns; when: !fieldIsSystemDefined" cdkDrag [cdkDragData]="row" cdkDragLockAxis="y"></mat-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns; when: !fieldIsSystemDefined"></mat-row>
 
       </mat-table>
       <!-- No Results Message -->

--- a/src/app/components/data-field-list/data-field-list.component.html
+++ b/src/app/components/data-field-list/data-field-list.component.html
@@ -72,15 +72,27 @@ project root for license information or contact permission@sei.cmu.edu for full 
     <div class="mat-table">
       <mat-table #table [dataSource]="dataFieldDataSource" matSort (matSortChange)="sortChanged($event)"
       cdkDropList [cdkDropListDisabled]="!allowDragAndDrop" (cdkDropListDropped)="dropHandler($event)">
+        <!-- Drag Handler column -->
+        <ng-container matColumnDef="draghandle">
+          <mat-header-cell *matHeaderCellDef class="mat-column-draghandle"></mat-header-cell>
+          <mat-cell *matCellDef="let element;" class="mat-column-draghandle">
+            <div class="draghandle-div">
+              <mat-icon cdkDragHandle class="mdi-18px down-12" fontIcon="mdi-drag-vertical"/>
+            </div>
+          </mat-cell>
+        </ng-container>
+        <ng-container matColumnDef="draghandleSpacer">
+          <mat-header-cell *matHeaderCellDef class="mat-column-draghandle"></mat-header-cell>
+          <mat-cell *matCellDef="let element;" class="mat-column-draghandle">
+            <span></span>
+          </mat-cell>
+        </ng-container>
         <!-- action column -->
         <ng-container matColumnDef="action">
           <mat-header-cell *matHeaderCellDef class="mat-column-action"></mat-header-cell>
           <mat-cell *matCellDef="let element" class="mat-column-action">
             <div class="action-div">
               <span *ngIf="element.displayOrder > 0">
-                <button cdkDragHandle mat-icon-button *ngIf="allowDragAndDrop" >
-                  <mat-icon class="mdi-18px" fontIcon="mdi-drag-vertical"/>
-                </button>
                 <button
                   mat-icon-button class="msel-action"
                   (click)="addOrEditDataField(element, showTemplates); $event.stopPropagation();"
@@ -188,8 +200,9 @@ project root for license information or contact permission@sei.cmu.edu for full 
         </ng-container>
         <!-- row definitions -->
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-        <mat-row *matRowDef="let row; columns: displayedColumns when: fieldIsSystemDefined"></mat-row>
+        <mat-row *matRowDef="let row; columns: systemFieldDisplayedColumns when: fieldIsSystemDefined"></mat-row>
         <mat-row *matRowDef="let row; columns: displayedColumns; when: !fieldIsSystemDefined" cdkDrag [cdkDragData]="row" cdkDragLockAxis="y"></mat-row>
+
       </mat-table>
       <!-- No Results Message -->
       <div class="text no-results" *ngIf="dataFieldDataSource?.filteredData.length === 0">No results found</div>

--- a/src/app/components/data-field-list/data-field-list.component.html
+++ b/src/app/components/data-field-list/data-field-list.component.html
@@ -77,7 +77,8 @@ project root for license information or contact permission@sei.cmu.edu for full 
           <mat-header-cell *matHeaderCellDef class="mat-column-draghandle"></mat-header-cell>
           <mat-cell *matCellDef="let element;" class="mat-column-draghandle">
             <div class="draghandle-div">
-              <mat-icon *ngIf="allowDragAndDrop" cdkDragHandle cdkDragRootElement="mat-row" cdkDrag [cdkDragData]="element" cdkDragLockAxis="y" [cdkDragPreviewClass]="userTheme" class="mdi-18px down-12" fontIcon="mdi-drag-vertical"/>
+              <mat-icon *ngIf="allowDragAndDrop" cdkDragHandle cdkDragRootElement="mat-row" cdkDrag [cdkDragData]="element"
+              cdkDragLockAxis="y" [cdkDragPreviewClass]="userTheme" class="mdi-18px down-12" fontIcon="mdi-drag-vertical"/>
             </div>
           </mat-cell>
         </ng-container>
@@ -202,7 +203,6 @@ project root for license information or contact permission@sei.cmu.edu for full 
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
         <mat-row *matRowDef="let row; columns: systemFieldDisplayedColumns when: fieldIsSystemDefined"></mat-row>
         <mat-row *matRowDef="let row; columns: displayedColumns; when: !fieldIsSystemDefined"></mat-row>
-
       </mat-table>
       <!-- No Results Message -->
       <div class="text no-results" *ngIf="dataFieldDataSource?.filteredData.length === 0">No results found</div>

--- a/src/app/components/data-field-list/data-field-list.component.html
+++ b/src/app/components/data-field-list/data-field-list.component.html
@@ -77,7 +77,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
           <mat-header-cell *matHeaderCellDef class="mat-column-draghandle"></mat-header-cell>
           <mat-cell *matCellDef="let element;" class="mat-column-draghandle">
             <div class="draghandle-div">
-              <mat-icon cdkDragHandle cdkDragRootElement="mat-row" cdkDrag [cdkDragData]="element" cdkDragLockAxis="y" [cdkDragPreviewClass]="userTheme" class="mdi-18px down-12" fontIcon="mdi-drag-vertical"/>
+              <mat-icon *ngIf="allowDragAndDrop" cdkDragHandle cdkDragRootElement="mat-row" cdkDrag [cdkDragData]="element" cdkDragLockAxis="y" [cdkDragPreviewClass]="userTheme" class="mdi-18px down-12" fontIcon="mdi-drag-vertical"/>
             </div>
           </mat-cell>
         </ng-container>
@@ -126,8 +126,8 @@ project root for license information or contact permission@sei.cmu.edu for full 
         </ng-container>
         <!-- events Column -->
         <ng-container matColumnDef="events">
-          <mat-header-cell title="Display on Scenario Events list?" *matHeaderCellDef class="mat-column-display">
-            Events
+          <mat-header-cell mat-sort-header="onScenarioEventList" title="Display on Scenario Events list?" *matHeaderCellDef class="mat-column-display">
+            &nbsp;&nbsp;&nbsp;&nbsp;Events
           </mat-header-cell>
           <mat-cell *matCellDef="let element" class="mat-column-display">
             <mat-checkbox
@@ -142,8 +142,8 @@ project root for license information or contact permission@sei.cmu.edu for full 
         </ng-container>
         <!-- exercise Column -->
         <ng-container matColumnDef="exercise">
-          <mat-header-cell title="Display on the Exercise View?" *matHeaderCellDef class="mat-column-display">
-            View
+          <mat-header-cell mat-sort-header="onExerciseView" title="Display on the Exercise View?" *matHeaderCellDef class="mat-column-display">
+            &nbsp;&nbsp;&nbsp;&nbsp;View
           </mat-header-cell>
           <mat-cell *matCellDef="let element" class="mat-column-display">
             <mat-checkbox
@@ -158,7 +158,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
         </ng-container>
         <!-- name Column -->
         <ng-container matColumnDef="name">
-          <mat-header-cell *matHeaderCellDef class="mat-column-name">
+          <mat-header-cell mat-sort-header="name" *matHeaderCellDef class="mat-column-name">
             Name
           </mat-header-cell>
           <mat-cell *matCellDef="let element" class="mat-column-name">
@@ -167,7 +167,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
         </ng-container>
         <!-- datatype Column -->
         <ng-container matColumnDef="datatype">
-          <mat-header-cell *matHeaderCellDef class="six-cell"> Data Type </mat-header-cell>
+          <mat-header-cell mat-sort-header="dataType" *matHeaderCellDef class="six-cell"> Data Type </mat-header-cell>
           <mat-cell *matCellDef="let element" class="six-cell">
             <div class="summary-text">{{ element.dataType }}</div>
           </mat-cell>
@@ -206,121 +206,6 @@ project root for license information or contact permission@sei.cmu.edu for full 
       </mat-table>
       <!-- No Results Message -->
       <div class="text no-results" *ngIf="dataFieldDataSource?.filteredData.length === 0">No results found</div>
-    </div>
-  </section>
-
-
-
-
-
-
-
-
-
-
-
-  <section *ngIf="false" class="scrolling-region">
-    <div style="text-align: left; width: 90%; padding-left: 10px; padding-top: 8px;">System Defined</div>
-    <!-- Move -->
-    <mat-expansion-panel disabled>
-      <mat-expansion-panel-header
-        class="mat-row"
-      >
-        <div class="mat-cell flex-row-cell left-cell">
-          <span style="width: 68px;">&nbsp;</span>1
-        </div>
-
-
-        <div class="flex-row-cell center-self left-cell">
-          <mat-checkbox
-            [(ngModel)]="msel.showMoveOnScenarioEventList"
-            [disabled]="!isContentDeveloper && !msel.hasRole(loggedInUserId, null).owner"
-            (change)="saveMsel()"
-            (click)="$event.stopPropagation();"
-          >
-          </mat-checkbox>
-          <mat-checkbox
-            [(ngModel)]="msel.showMoveOnExerciseView"
-            [disabled]="!isContentDeveloper && !msel.hasRole(loggedInUserId, null).owner"
-            (change)="saveMsel()"
-            (click)="$event.stopPropagation();"
-            class="exercise-view-checkbox"
-          >
-          </mat-checkbox>
-        </div>
-
-
-        <div class="mat-cell two-cell center-self">Move</div>
-        <div class="mat-cell one-cell center-self">Move</div>
-        <div class="mat-cell two-cell center-self">Gallery Move</div>
-        <div class="mat-cell two-cell center-self">&nbsp;</div>
-      </mat-expansion-panel-header>
-    </mat-expansion-panel>
-    <!-- Group -->
-    <mat-expansion-panel disabled>
-      <mat-expansion-panel-header
-        class="mat-row"
-      >
-        <div class="mat-cell flex-row-cell left-cell">
-          <span style="width: 68px;">&nbsp;</span>2
-        </div>
-        <div class="flex-row-cell center-self left-cell">
-          <mat-checkbox
-            [(ngModel)]="msel.showGroupOnScenarioEventList"
-            [disabled]="!isContentDeveloper && !msel.hasRole(loggedInUserId, null).owner"
-            (change)="saveMsel()"
-            (click)="$event.stopPropagation();"
-          >
-          </mat-checkbox>
-          <mat-checkbox
-            [(ngModel)]="msel.showGroupOnExerciseView"
-            [disabled]="!isContentDeveloper && !msel.hasRole(loggedInUserId, null).owner"
-            (change)="saveMsel()"
-            (click)="$event.stopPropagation();"
-            class="exercise-view-checkbox"
-          >
-          </mat-checkbox>
-        </div>
-        <div class="mat-cell two-cell center-self">Group</div>
-        <div class="mat-cell one-cell center-self">Integer</div>
-        <div class="mat-cell two-cell center-self">Gallery Inject</div>
-        <div class="mat-cell two-cell center-self">&nbsp;</div>
-      </mat-expansion-panel-header>
-    </mat-expansion-panel>
-    <!-- Execution Time -->
-    <mat-expansion-panel disabled>
-      <mat-expansion-panel-header
-        class="mat-row"
-      >
-        <div class="mat-cell flex-row-cell left-cell">
-          <span style="width: 68px;">&nbsp;</span>3
-        </div>
-        <div class="flex-row-cell center-self left-cell">
-          <mat-checkbox
-            [(ngModel)]="msel.showTimeOnScenarioEventList"
-            [disabled]="!isContentDeveloper && !msel.hasRole(loggedInUserId, null).owner"
-            (change)="saveMsel()"
-            (click)="$event.stopPropagation();"
-          >
-          </mat-checkbox>
-          <mat-checkbox
-            [(ngModel)]="msel.showTimeOnExerciseView"
-            [disabled]="!isContentDeveloper && !msel.hasRole(loggedInUserId, null).owner"
-            (change)="saveMsel()"
-            (click)="$event.stopPropagation();"
-            class="exercise-view-checkbox"
-          >
-          </mat-checkbox>
-        </div>
-        <div class="mat-cell two-cell center-self">Execution Time</div>
-        <div class="mat-cell one-cell center-self">DateTime</div>
-        <div class="mat-cell two-cell center-self">- - -</div>
-        <div class="mat-cell two-cell center-self">&nbsp;</div>
-      </mat-expansion-panel-header>
-    </mat-expansion-panel>
-    <hr />
-    <div class="center-self" style="text-align: left; width: 90%; padding-left: 10px;">
-      User Defined
     </div>
   </section>
 </div>

--- a/src/app/components/data-field-list/data-field-list.component.html
+++ b/src/app/components/data-field-list/data-field-list.component.html
@@ -70,13 +70,17 @@ project root for license information or contact permission@sei.cmu.edu for full 
   <section class="scrolling-region">
     <div class="gallery-warning" *ngIf="!!galleryToDo()">** Gallery Parameters not assigned:  {{ galleryToDo() }}</div>
     <div class="mat-table">
-      <mat-table #table [dataSource]="dataFieldDataSource" matSort (matSortChange)="sortChanged($event)">
+      <mat-table #table [dataSource]="dataFieldDataSource" matSort (matSortChange)="sortChanged($event)"
+      cdkDropList [cdkDropListDisabled]="!allowDragAndDrop" (cdkDropListDropped)="dropHandler($event)">
         <!-- action column -->
         <ng-container matColumnDef="action">
           <mat-header-cell *matHeaderCellDef class="mat-column-action"></mat-header-cell>
           <mat-cell *matCellDef="let element" class="mat-column-action">
             <div class="action-div">
               <span *ngIf="element.displayOrder > 0">
+                <button cdkDragHandle mat-icon-button *ngIf="allowDragAndDrop" >
+                  <mat-icon class="mdi-18px" fontIcon="mdi-drag-vertical"/>
+                </button>
                 <button
                   mat-icon-button class="msel-action"
                   (click)="addOrEditDataField(element, showTemplates); $event.stopPropagation();"
@@ -184,7 +188,8 @@ project root for license information or contact permission@sei.cmu.edu for full 
         </ng-container>
         <!-- row definitions -->
         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-        <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns when: fieldIsSystemDefined"></mat-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns; when: !fieldIsSystemDefined" cdkDrag [cdkDragData]="row" cdkDragLockAxis="y"></mat-row>
       </mat-table>
       <!-- No Results Message -->
       <div class="text no-results" *ngIf="dataFieldDataSource?.filteredData.length === 0">No results found</div>

--- a/src/app/components/data-field-list/data-field-list.component.scss
+++ b/src/app/components/data-field-list/data-field-list.component.scss
@@ -59,14 +59,14 @@
 }
 
 .mat-column-action {
-  flex: 0 0 150px;
+  flex: 0 0 180px;
   flex-direction: row;
   padding: 0;
   word-wrap: none;
 }
 
 .action-div {
-  width: 130px;
+  width: 170px;
 }
 
 .mat-column-summary {

--- a/src/app/components/data-field-list/data-field-list.component.scss
+++ b/src/app/components/data-field-list/data-field-list.component.scss
@@ -46,7 +46,7 @@
 }
 
 .mat-column-display {
-  flex: 0 0 50px;
+  flex: 0 0 70px;
   justify-content: center;
   justify-self: center;
   align-self: center;

--- a/src/app/components/data-field-list/data-field-list.component.scss
+++ b/src/app/components/data-field-list/data-field-list.component.scss
@@ -261,14 +261,14 @@
   margin-top: 5px;
 }
 
-.cdk-drag-preview.light-theme {
+mat-row.cdk-drag-preview.light-theme {
   border-top: 1pt solid gray;
   width: 100%;
   background: #f1f1f2 !important;
   color: #242526;
 }
 
-.cdk-drag-preview.dark-theme {
+mat-row.cdk-drag-preview.dark-theme {
   border-top: 1pt solid gray;
   width: 100%;
   background: #373739 !important;

--- a/src/app/components/data-field-list/data-field-list.component.scss
+++ b/src/app/components/data-field-list/data-field-list.component.scss
@@ -58,6 +58,17 @@
   padding: 1%;
 }
 
+.draghandle-div {
+  width: 20px;
+}
+
+.mat-column-draghandle {
+  flex: 0 0 20px;
+  flex-direction: row;
+  padding: 0;
+  word-wrap: none;
+}
+
 .mat-column-action {
   flex: 0 0 180px;
   flex-direction: row;
@@ -168,6 +179,10 @@
   margin-top: -12px;
 }
 
+.down-12 {
+  margin-top: 12px;
+}
+
 .copy-icon {
   margin-top: -8px;
 }
@@ -244,4 +259,18 @@
   font-size: small;
   color: orangered;
   margin-top: 5px;
+}
+
+.cdk-drag-preview.light-theme {
+  border-top: 1pt solid gray;
+  width: 100%;
+  background: #f1f1f2 !important;
+  color: #242526;
+}
+
+.cdk-drag-preview.dark-theme {
+  border-top: 1pt solid gray;
+  width: 100%;
+  background: #373739 !important;
+  color: #efefef;
 }

--- a/src/app/components/data-field-list/data-field-list.component.ts
+++ b/src/app/components/data-field-list/data-field-list.component.ts
@@ -148,7 +148,7 @@ export class DataFieldListComponent implements OnDestroy, OnInit {
 
   ngOnInit() {
     if (this.showTemplates) {
-      this.displayedColumns.splice(1, 2);
+      this.displayedColumns.splice(2, 2);
     }
   }
 
@@ -265,6 +265,14 @@ export class DataFieldListComponent implements OnDestroy, OnInit {
 
   sortChanged(sort: Sort) {
     this.sort = sort;
+    if (
+      (this.sort && this.sort.active && this.sort.direction) ||
+      this.filterString
+    ) {
+      this.allowDragAndDrop = false;
+    } else {
+      this.allowDragAndDrop = !this.showTemplates;
+    }
     this.dataFieldDataSource.data = this.getFilteredDataFields(
       this.msel.id,
       this.injectType.id,
@@ -354,14 +362,6 @@ export class DataFieldListComponent implements OnDestroy, OnInit {
       filteredDataFields.sort((a, b) => this.sortDataFields(a, b));
     }
 
-    if (
-      (this.sort && this.sort.active && this.sort.direction) ||
-      this.filterString
-    ) {
-      this.allowDragAndDrop = false;
-    } else {
-      this.allowDragAndDrop = true;
-    }
     const returnArray =
       this.showTemplates || (!mselId && !injectTypeId)
         ? filteredDataFields

--- a/src/app/components/data-field-list/data-field-list.component.ts
+++ b/src/app/components/data-field-list/data-field-list.component.ts
@@ -10,6 +10,7 @@ import {
   DataFieldType,
   InjectType
 } from 'src/app/generated/blueprint.api';
+import { Theme } from '@cmusei/crucible-common';
 import { MselPlus } from 'src/app/data/msel/msel-data.service';
 import { MselQuery } from 'src/app/data/msel/msel.query';
 import { Sort } from '@angular/material/sort';
@@ -34,6 +35,8 @@ export class DataFieldListComponent implements OnDestroy, OnInit {
   @Input() loggedInUserId: string;
   @Input() isContentDeveloper: boolean;
   @Input() showTemplates: boolean;
+  @Input() userTheme: Theme;
+
   msel = new MselPlus();
   injectType: InjectType = { id: null };
   dataFieldList: DataField[] = [];
@@ -53,7 +56,17 @@ export class DataFieldListComponent implements OnDestroy, OnInit {
   templateDataSource = new MatTableDataSource<DataField>(
     new Array<DataField>()
   );
+  systemFieldDisplayedColumns: string[] = [
+    'draghandleSpacer',
+    'action',
+    'events',
+    'exercise',
+    'name',
+    'datatype',
+    'options',
+  ];
   displayedColumns: string[] = [
+    'draghandle',
     'action',
     'events',
     'exercise',

--- a/src/app/components/data-field-list/data-field-list.component.ts
+++ b/src/app/components/data-field-list/data-field-list.component.ts
@@ -46,7 +46,6 @@ export class DataFieldListComponent implements OnDestroy, OnInit {
   filterControl = new UntypedFormControl();
   filterString = '';
   sort: Sort = { active: '', direction: '' };
-  sortedDataFields: DataField[] = [];
   allowDragAndDrop = true;
   dataFieldTypes = DataFieldType;
   systemDefinedDataFields = new Array<DataField>();
@@ -451,7 +450,25 @@ export class DataFieldListComponent implements OnDestroy, OnInit {
     this.mselDataService.updateMsel(this.msel);
   }
 
-  dropHandler(event: CdkDragDrop<string[]>) {}
+  dropHandler(event: CdkDragDrop<string[]>) {
+    // NOTE: The event index only considers rows that were draggable starting at 0
+    // The nonSystemDefaultFieldStartIndex tracks which actual index is equivalent to zero
+    const nonSystemDefaultFieldStartIndex =
+      this.dataFieldDataSource.data.findIndex(
+        (df, index) => !this.fieldIsSystemDefined(index, df)
+      );
+    const prevIndex = event.previousIndex + nonSystemDefaultFieldStartIndex;
+    const currIndex = event.currentIndex + nonSystemDefaultFieldStartIndex;
+    // sanity check
+    if (nonSystemDefaultFieldStartIndex >= 0 && prevIndex !== currIndex) {
+      const droppedField = event.item.data;
+      const targetField = this.dataFieldDataSource.data[currIndex];
+      this.saveDataField({
+        ...droppedField,
+        displayOrder: targetField.displayOrder,
+      });
+    }
+  }
 
   ngOnDestroy() {
     this.unsubscribe$.next(null);

--- a/src/app/components/inject-page/inject-page.component.ts
+++ b/src/app/components/inject-page/inject-page.component.ts
@@ -18,41 +18,40 @@ import { MselDataService } from 'src/app/data/msel/msel-data.service';
 import { TeamDataService } from 'src/app/data/team/team-data.service';
 import { OrganizationDataService } from 'src/app/data/organization/organization-data.service';
 import { DataFieldDataService } from 'src/app/data/data-field/data-field-data.service';
-import { DataOptionDataService } from 'src/app/data/data-option/data-option-data.service';
 import { DataValueDataService } from 'src/app/data/data-value/data-value-data.service';
-import { ScenarioEventDataService, ScenarioEventPlus, DataValuePlus } from 'src/app/data/scenario-event/scenario-event-data.service';
+import {
+  ScenarioEventDataService,
+  ScenarioEventPlus,
+  DataValuePlus,
+} from 'src/app/data/scenario-event/scenario-event-data.service';
 import { MselQuery } from 'src/app/data/msel/msel.query';
 import { DataFieldQuery } from 'src/app/data/data-field/data-field.query';
-import { DataOptionQuery } from 'src/app/data/data-option/data-option.query';
 import { MoveQuery } from 'src/app/data/move/move.query';
 import {
   DataField,
   DataFieldType,
-  DataOption,
   DataValue,
   Move,
-  ScenarioEvent,
   Organization,
   MselItemStatus,
   Team,
   User,
-  Card
+  Card,
 } from 'src/app/generated/blueprint.api';
 import { UntypedFormControl } from '@angular/forms';
 import { MselPlus } from 'src/app/data/msel/msel-data.service';
 import { DataValueQuery } from 'src/app/data/data-value/data-value.query';
 import { ScenarioEventQuery } from 'src/app/data/scenario-event/scenario-event.query';
 import { Sort } from '@angular/material/sort';
-import { Component, Input} from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { AngularEditorConfig } from '@kolkov/angular-editor';
 import { CardQuery } from 'src/app/data/card/card.query';
 
 @Component({
   selector: 'app-inject-page',
   templateUrl: './inject-page.component.html',
-  styleUrls: ['./inject-page.component.scss']
+  styleUrls: ['./inject-page.component.scss'],
 })
-
 export class InjectPageComponent {
   @Input() userTheme: Theme;
   @Input() isContentDeveloper: boolean;
@@ -73,7 +72,6 @@ export class InjectPageComponent {
   cardList: Card[] = [];
   allDataFields: DataField[] = [];
   dateFormControls = new Map<string, UntypedFormControl>();
-  sortedDataOptions: DataOption[] = [];
   dataValues: DataValue[] = [];
   scenarioEvent: ScenarioEventPlus = {} as ScenarioEventPlus;
   moveList: Move[] = [];
@@ -84,13 +82,24 @@ export class InjectPageComponent {
     scenarioEventId: '',
     dataFieldId: '',
     value: '',
-    valueArray: []
+    valueArray: [],
   } as DataValuePlus;
   organizationList: Organization[] = [];
   sort: Sort = { active: 'deltaSeconds', direction: 'asc' };
-  itemStatus = [MselItemStatus.Pending, MselItemStatus.Entered, MselItemStatus.Approved, MselItemStatus.Complete, MselItemStatus.Deployed, MselItemStatus.Archived];
-  darkThemeTint = this.settingsService.settings.DarkThemeTint ? this.settingsService.settings.DarkThemeTint : 0.7;
-  lightThemeTint = this.settingsService.settings.LightThemeTint ? this.settingsService.settings.LightThemeTint : 0.4;
+  itemStatus = [
+    MselItemStatus.Pending,
+    MselItemStatus.Entered,
+    MselItemStatus.Approved,
+    MselItemStatus.Complete,
+    MselItemStatus.Deployed,
+    MselItemStatus.Archived,
+  ];
+  darkThemeTint = this.settingsService.settings.DarkThemeTint
+    ? this.settingsService.settings.DarkThemeTint
+    : 0.7;
+  lightThemeTint = this.settingsService.settings.LightThemeTint
+    ? this.settingsService.settings.LightThemeTint
+    : 0.4;
   selectedEventIdList: string[] = [];
   mselUsers: User[] = [];
   showRealTime = false;
@@ -121,12 +130,10 @@ export class InjectPageComponent {
     private titleService: Title,
     private teamDataService: TeamDataService,
     private dataFieldDataService: DataFieldDataService,
-    private dataOptionDataService: DataOptionDataService,
     private dataValueDataService: DataValueDataService,
     private scenarioEventDataService: ScenarioEventDataService,
     private mselQuery: MselQuery,
     private dataFieldQuery: DataFieldQuery,
-    private dataOptionQuery: DataOptionQuery,
     private moveQuery: MoveQuery,
     private dataValueQuery: DataValueQuery,
     private scenarioEventQuery: ScenarioEventQuery,
@@ -134,7 +141,10 @@ export class InjectPageComponent {
     private activatedRoute: ActivatedRoute
   ) {
     // set image
-    this.imageFilePath = this.settingsService.settings.AppTopBarImage.replace('white', 'blue');
+    this.imageFilePath = this.settingsService.settings.AppTopBarImage.replace(
+      'white',
+      'blue'
+    );
     this.titleService.setTitle(this.appTitle);
     // Set the display settings from config file
     this.topbarColor = this.settingsService.settings.AppTopBarHexColor
@@ -143,105 +153,134 @@ export class InjectPageComponent {
     this.topbarTextColor = this.settingsService.settings.AppTopBarHexTextColor
       ? this.settingsService.settings.AppTopBarHexTextColor
       : this.topbarTextColor;
-    this.activatedRoute.queryParamMap.pipe(takeUntil(this.unsubscribe$)).subscribe(queryParams => {
-      // load the selected MSEL data
-      const mselId = queryParams.get('msel');
-      const scenarioEventId = queryParams.get('scenarioEvent');
-      this.dataValueId = queryParams.get('dataValue');
-      this.scenarioEventId = scenarioEventId;
-      if (mselId && this.mselId !== mselId) {
-        // load the selected MSEL and make it active
-        this.mselDataService.loadById(mselId);
-        this.mselDataService.setActive(mselId);
-        // // load the MSELs moves
-        this.moveDataService.loadByMsel(mselId);
-        // // load the MSEL Teams
-        this.teamDataService.loadByMsel(mselId);
-        // // load the MSEL organizations and templates
-        this.organizationDataService.loadByMsel(mselId);
-        // // load data fields, options, and values
-        this.dataFieldDataService.loadByMsel(mselId);
-        this.dataOptionDataService.loadByMsel(mselId);
-        this.dataValueDataService.loadByMsel(mselId);
-        // // load scenario events
-        if (scenarioEventId) {
-          this.scenarioEventDataService.loadById(scenarioEventId);
+    this.activatedRoute.queryParamMap
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((queryParams) => {
+        // load the selected MSEL data
+        const mselId = queryParams.get('msel');
+        const scenarioEventId = queryParams.get('scenarioEvent');
+        this.dataValueId = queryParams.get('dataValue');
+        this.scenarioEventId = scenarioEventId;
+        if (mselId && this.mselId !== mselId) {
+          // load the selected MSEL and make it active
+          this.mselDataService.loadById(mselId);
+          this.mselDataService.setActive(mselId);
+          // // load the MSELs moves
+          this.moveDataService.loadByMsel(mselId);
+          // // load the MSEL Teams
+          this.teamDataService.loadByMsel(mselId);
+          // // load the MSEL organizations and templates
+          this.organizationDataService.loadByMsel(mselId);
+          // // load data fields and values
+          this.dataFieldDataService.loadByMsel(mselId);
+          this.dataValueDataService.loadByMsel(mselId);
+          // // load scenario events
+          if (scenarioEventId) {
+            this.scenarioEventDataService.loadById(scenarioEventId);
+          }
         }
-      }
-    });
-    // subscribe to the active MSEL
-    (this.mselQuery.selectActive() as Observable<MselPlus>).pipe(takeUntil(this.unsubscribe$)).subscribe(msel => {
-      if (msel && this.msel.id !== msel.id) {
-        this.msel = this.getEditableMsel(msel) as MselPlus;
-      }
-    });
-    // subscribe to data fields
-    this.dataFieldQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(dataFields => {
-      this.getSortedDataFields(dataFields);
-    });
-    // subscribe to the data options
-    this.dataOptionQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(dataOptions => {
-      this.sortedDataOptions = dataOptions.sort((a, b) => +a.displayOrder < +b.displayOrder ? -1 : 1);
-    });
-    // subscribe to data values
-    this.dataValueQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(dataValues => {
-      this.dataValues = [];
-      dataValues.forEach(dv => {
-        this.dataValues.push({ ... dv });
       });
-    });
-    this.cardQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(cards => {
-      this.cardList = cards;
-    });
+    // subscribe to the active MSEL
+    (this.mselQuery.selectActive() as Observable<MselPlus>)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((msel) => {
+        if (msel && this.msel.id !== msel.id) {
+          this.msel = this.getEditableMsel(msel) as MselPlus;
+        }
+      });
+    // subscribe to data fields
+    this.dataFieldQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((dataFields) => {
+        this.getSortedDataFields(dataFields);
+      });
+    // subscribe to data values
+    this.dataValueQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((dataValues) => {
+        this.dataValues = [];
+        dataValues.forEach((dv) => {
+          this.dataValues.push({ ...dv });
+        });
+      });
+    this.cardQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((cards) => {
+        this.cardList = cards;
+      });
 
-    (this.scenarioEventQuery.selectAll()).pipe(takeUntil(this.unsubscribe$)).subscribe(scenarioEvents => {
-      if (scenarioEvents && scenarioEvents.length > 0) {
-        this.scenarioEvent = scenarioEvents.find(m => m.id === this.scenarioEventId) as ScenarioEventPlus;
-      }
-    });
-    this.moveQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(moves => {
-      this.moveList = moves.sort((a, b) => +a.moveNumber < +b.moveNumber ? -1 : 1);
-    });
+    this.scenarioEventQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((scenarioEvents) => {
+        if (scenarioEvents && scenarioEvents.length > 0) {
+          this.scenarioEvent = scenarioEvents.find(
+            (m) => m.id === this.scenarioEventId
+          ) as ScenarioEventPlus;
+        }
+      });
+    this.moveQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((moves) => {
+        this.moveList = moves.sort((a, b) =>
+          +a.moveNumber < +b.moveNumber ? -1 : 1
+        );
+      });
   }
 
   topBarNavigate(url): void {
     this.router.navigate([url]);
   }
 
-  getEditableMsel (msel: MselPlus): MselPlus {
+  getEditableMsel(msel: MselPlus): MselPlus {
     const editableMsel = new MselPlus();
     Object.assign(editableMsel, msel);
-    editableMsel.teams = editableMsel.teams.slice(0).sort((a, b) => a.shortName.toLowerCase() < b.shortName.toLowerCase() ? -1 : 1);
+    editableMsel.teams = editableMsel.teams
+      .slice(0)
+      .sort((a, b) =>
+        a.shortName.toLowerCase() < b.shortName.toLowerCase() ? -1 : 1
+      );
 
     return editableMsel;
   }
 
   getSortedDataFields(dataFields: DataField[]) {
     if (dataFields) {
-      this.sortedDataFields = dataFields
-        .sort((a, b) => +a.displayOrder > +b.displayOrder ? 1 : -1);
-      this.allDataFields = dataFields
-        .sort((a, b) => +a.displayOrder > +b.displayOrder ? 1 : -1);
+      this.sortedDataFields = dataFields.sort((a, b) =>
+        +a.displayOrder > +b.displayOrder ? 1 : -1
+      );
+      this.allDataFields = dataFields.sort((a, b) =>
+        +a.displayOrder > +b.displayOrder ? 1 : -1
+      );
     }
     // create date form controls
-    this.allDataFields.forEach(df => {
+    this.allDataFields.forEach((df) => {
       if (df.dataType === DataFieldType.DateTime) {
         this.dateFormControls[df.id] = new UntypedFormControl();
       }
     });
   }
 
-  getEditableScenarioEvents(scenarioEvents: ScenarioEventPlus[]): ScenarioEventPlus[] {
+  getEditableScenarioEvents(
+    scenarioEvents: ScenarioEventPlus[]
+  ): ScenarioEventPlus[] {
     const editableList: ScenarioEventPlus[] = [];
-    scenarioEvents.forEach(scenarioEvent => {
-      const newScenarioEvent = { ...scenarioEvent};
+    scenarioEvents.forEach((scenarioEvent) => {
+      const newScenarioEvent = { ...scenarioEvent };
       editableList.push(newScenarioEvent);
     });
 
     return editableList;
   }
 
-  getDataValue(scenarioEvent: ScenarioEventPlus, dataFieldName: string): DataValuePlus {
+  getDataValue(
+    scenarioEvent: ScenarioEventPlus,
+    dataFieldName: string
+  ): DataValuePlus {
     if (!(this.msel && scenarioEvent && scenarioEvent.id)) {
       return this.blankDataValue;
     }
@@ -249,10 +288,15 @@ export class InjectPageComponent {
     if (!dataFieldId) {
       return this.blankDataValue;
     }
-    let dataValuePlus = this.dataValues.find(dv =>
-      dv.dataFieldId === dataFieldId && dv.scenarioEventId === scenarioEvent.id) as DataValuePlus;
+    let dataValuePlus = this.dataValues.find(
+      (dv) =>
+        dv.dataFieldId === dataFieldId &&
+        dv.scenarioEventId === scenarioEvent.id
+    ) as DataValuePlus;
     if (dataValuePlus) {
-      dataValuePlus.valueArray = dataValuePlus.value ? dataValuePlus.value.split(', ') : [];
+      dataValuePlus.valueArray = dataValuePlus.value
+        ? dataValuePlus.value.split(', ')
+        : [];
     } else {
       dataValuePlus = this.blankDataValue;
     }
@@ -261,14 +305,18 @@ export class InjectPageComponent {
 
   getDataValueById() {
     if (this.dataValueId) {
-      const dataValue = this.dataValues.find(dv => dv.id === this.dataValueId);
+      const dataValue = this.dataValues.find(
+        (dv) => dv.id === this.dataValueId
+      );
       return dataValue ? dataValue.value : '';
     }
     return '';
   }
 
   getDataFieldIdByName(scenarioEvent: ScenarioEventPlus, name: string): string {
-    const dataField = this.allDataFields.find(df => df.name.toLowerCase() === name.toLowerCase());
+    const dataField = this.allDataFields.find(
+      (df) => df.name.toLowerCase() === name.toLowerCase()
+    );
     return dataField ? dataField.id : '';
   }
 
@@ -276,11 +324,15 @@ export class InjectPageComponent {
     if (!(this.msel && this.scenarioEvent && this.scenarioEvent.id)) {
       return '';
     }
-    const dataField = this.allDataFields.find(df => df.name === columnName);
+    const dataField = this.allDataFields.find((df) => df.name === columnName);
     if (!dataField) {
       return '';
     }
-    const dataValue = this.dataValues.find(dv => dv.dataFieldId === dataField.id && dv.scenarioEventId === this.scenarioEvent.id);
+    const dataValue = this.dataValues.find(
+      (dv) =>
+        dv.dataFieldId === dataField.id &&
+        dv.scenarioEventId === this.scenarioEvent.id
+    );
 
     if (dataValue) {
       if (dataField.dataType === 'Card') {
@@ -297,11 +349,15 @@ export class InjectPageComponent {
     if (!scenarioEvent) {
       return '';
     }
-    const titleField = this.allDataFields.find(df => df.name === 'Title');
+    const titleField = this.allDataFields.find((df) => df.name === 'Title');
     if (!titleField) {
       return '';
     }
-    const titleDataValue = this.dataValues.find(dv => dv.dataFieldId === titleField.id && dv.scenarioEventId === scenarioEvent.id);
+    const titleDataValue = this.dataValues.find(
+      (dv) =>
+        dv.dataFieldId === titleField.id &&
+        dv.scenarioEventId === scenarioEvent.id
+    );
     return titleDataValue ? titleDataValue.value : '';
   }
 
@@ -313,7 +369,7 @@ export class InjectPageComponent {
   }
 
   getCardNameById(cardId: string): string {
-    const card = this.cardList.find(c => c.id === cardId);
+    const card = this.cardList.find((c) => c.id === cardId);
     return card ? card.name : 'Unknown';
   }
 
@@ -324,14 +380,20 @@ export class InjectPageComponent {
   }
 
   openInNewTab(scenarioEventId: string, dataFieldId: string) {
-    const dataValue = this.dataValues.find(dv => dv.dataFieldId === dataFieldId && dv.scenarioEventId === scenarioEventId);
+    const dataValue = this.dataValues.find(
+      (dv) =>
+        dv.dataFieldId === dataFieldId && dv.scenarioEventId === scenarioEventId
+    );
     if (dataValue && dataValue.id) {
-      const url = location.origin +
-        '/injectpage?msel=' + this.msel.id +
-        '&scenarioEvent=' + this.scenarioEventId +
-        '&dataValue=' + dataValue.id;
+      const url =
+        location.origin +
+        '/injectpage?msel=' +
+        this.msel.id +
+        '&scenarioEvent=' +
+        this.scenarioEventId +
+        '&dataValue=' +
+        dataValue.id;
       window.open(url);
     }
   }
-
 }

--- a/src/app/components/msel-playbook/msel-playbook.component.ts
+++ b/src/app/components/msel-playbook/msel-playbook.component.ts
@@ -15,29 +15,30 @@ import { MselDataService } from 'src/app/data/msel/msel-data.service';
 import { TeamDataService } from 'src/app/data/team/team-data.service';
 import { OrganizationDataService } from 'src/app/data/organization/organization-data.service';
 import { DataFieldDataService } from 'src/app/data/data-field/data-field-data.service';
-import { DataOptionDataService } from 'src/app/data/data-option/data-option-data.service';
 import { DataValueDataService } from 'src/app/data/data-value/data-value-data.service';
-import { ScenarioEventDataService, ScenarioEventPlus, DataValuePlus } from 'src/app/data/scenario-event/scenario-event-data.service';
+import {
+  ScenarioEventDataService,
+  ScenarioEventPlus,
+  DataValuePlus,
+} from 'src/app/data/scenario-event/scenario-event-data.service';
 import { MselQuery } from 'src/app/data/msel/msel.query';
 import { DataFieldQuery } from 'src/app/data/data-field/data-field.query';
-import { DataOptionQuery } from 'src/app/data/data-option/data-option.query';
 import { MoveQuery } from 'src/app/data/move/move.query';
 import {
   DataField,
   DataFieldType,
-  DataOption,
   DataValue,
   Move,
   ScenarioEvent,
   MselItemStatus,
-  Card
+  Card,
 } from 'src/app/generated/blueprint.api';
 import { UntypedFormControl } from '@angular/forms';
 import { MselPlus } from 'src/app/data/msel/msel-data.service';
 import { DataValueQuery } from 'src/app/data/data-value/data-value.query';
 import { ScenarioEventQuery } from 'src/app/data/scenario-event/scenario-event.query';
 import { Sort } from '@angular/material/sort';
-import { Component, Input} from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { UIDataService } from 'src/app/data/ui/ui-data.service';
 import { CardQuery } from 'src/app/data/card/card.query';
 import { CardDataService } from 'src/app/data/card/card-data.service';
@@ -46,9 +47,9 @@ import { PageEvent } from '@angular/material/paginator';
 @Component({
   selector: 'app-msel-playbook',
   templateUrl: './msel-playbook.component.html',
-  styleUrls: ['./msel-playbook.component.scss']
+  styleUrls: ['./msel-playbook.component.scss'],
 })
-export class MselPlaybookComponent{
+export class MselPlaybookComponent {
   @Input() userTheme: Theme;
   @Input() isContentDeveloper: boolean;
   @Input() loggedInUserId: string;
@@ -64,7 +65,6 @@ export class MselPlaybookComponent{
   cardList: Card[] = [];
   allDataFields: DataField[] = [];
   dateFormControls = new Map<string, UntypedFormControl>();
-  sortedDataOptions: DataOption[] = [];
   dataValues: DataValue[] = [];
   mselScenarioEvents: ScenarioEventPlus[] = [];
   sortedScenarioEvents: ScenarioEventPlus[] = [];
@@ -77,12 +77,23 @@ export class MselPlaybookComponent{
     scenarioEventId: '',
     dataFieldId: '',
     value: '',
-    valueArray: []
+    valueArray: [],
   } as DataValuePlus;
   sort: Sort = { active: 'deltaSeconds', direction: 'asc' };
-  itemStatus = [MselItemStatus.Pending, MselItemStatus.Entered, MselItemStatus.Approved, MselItemStatus.Complete, MselItemStatus.Deployed, MselItemStatus.Archived];
-  darkThemeTint = this.settingsService.settings.DarkThemeTint ? this.settingsService.settings.DarkThemeTint : 0.7;
-  lightThemeTint = this.settingsService.settings.LightThemeTint ? this.settingsService.settings.LightThemeTint : 0.4;
+  itemStatus = [
+    MselItemStatus.Pending,
+    MselItemStatus.Entered,
+    MselItemStatus.Approved,
+    MselItemStatus.Complete,
+    MselItemStatus.Deployed,
+    MselItemStatus.Archived,
+  ];
+  darkThemeTint = this.settingsService.settings.DarkThemeTint
+    ? this.settingsService.settings.DarkThemeTint
+    : 0.7;
+  lightThemeTint = this.settingsService.settings.LightThemeTint
+    ? this.settingsService.settings.LightThemeTint
+    : 0.4;
 
   constructor(
     private settingsService: ComnSettingsService,
@@ -91,12 +102,10 @@ export class MselPlaybookComponent{
     private mselDataService: MselDataService,
     private teamDataService: TeamDataService,
     private dataFieldDataService: DataFieldDataService,
-    private dataOptionDataService: DataOptionDataService,
     private dataValueDataService: DataValueDataService,
     private scenarioEventDataService: ScenarioEventDataService,
     private mselQuery: MselQuery,
     private dataFieldQuery: DataFieldQuery,
-    private dataOptionQuery: DataOptionQuery,
     private moveQuery: MoveQuery,
     private dataValueQuery: DataValueQuery,
     private scenarioEventQuery: ScenarioEventQuery,
@@ -106,74 +115,106 @@ export class MselPlaybookComponent{
     private activatedRoute: ActivatedRoute
   ) {
     // set image
-    this.activatedRoute.paramMap.pipe(takeUntil(this.unsubscribe$)).subscribe(params => {
-      // load the selected MSEL data
-      const mselId = params.get('id');
-      const scenarioEventId = params.get('scenarioEventId');
-      this.scenarioEventId = scenarioEventId;
-      if (mselId && this.selectedMselId !== mselId) {
-        // load the selected MSEL and make it active
-        this.mselDataService.loadById(mselId);
-        this.mselDataService.setActive(mselId);
-        // // load the MSELs moves
-        this.moveDataService.loadByMsel(mselId);
-        // // load the MSEL Teams
-        this.teamDataService.loadByMsel(mselId);
-        // // load the MSEL organizations and templates
-        this.organizationDataService.loadByMsel(mselId);
-        // // load data fields, options, and values
-        this.dataFieldDataService.loadByMsel(mselId);
-        this.dataOptionDataService.loadByMsel(mselId);
-        this.dataValueDataService.loadByMsel(mselId);
-        // // load scenario events
-        if (scenarioEventId) {
-          this.scenarioEventDataService.loadById(scenarioEventId);
+    this.activatedRoute.paramMap
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((params) => {
+        // load the selected MSEL data
+        const mselId = params.get('id');
+        const scenarioEventId = params.get('scenarioEventId');
+        this.scenarioEventId = scenarioEventId;
+        if (mselId && this.selectedMselId !== mselId) {
+          // load the selected MSEL and make it active
+          this.mselDataService.loadById(mselId);
+          this.mselDataService.setActive(mselId);
+          // // load the MSELs moves
+          this.moveDataService.loadByMsel(mselId);
+          // // load the MSEL Teams
+          this.teamDataService.loadByMsel(mselId);
+          // // load the MSEL organizations and templates
+          this.organizationDataService.loadByMsel(mselId);
+          // // load data fields and values
+          this.dataFieldDataService.loadByMsel(mselId);
+          this.dataValueDataService.loadByMsel(mselId);
+          // // load scenario events
+          if (scenarioEventId) {
+            this.scenarioEventDataService.loadById(scenarioEventId);
+          }
         }
-      }
-    });
-    // subscribe to the active MSEL
-    (this.mselQuery.selectActive() as Observable<MselPlus>).pipe(takeUntil(this.unsubscribe$)).subscribe(msel => {
-      if (msel && this.msel.id !== msel.id) {
-        this.msel = this.getEditableMsel(msel) as MselPlus;
-      }
-    });
-    // subscribe to data fields
-    this.dataFieldQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(dataFields => {
-      this.getSortedDataFields(dataFields);
-    });
-    // subscribe to the data options
-    this.dataOptionQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(dataOptions => {
-      this.sortedDataOptions = dataOptions.sort((a, b) => +a.displayOrder < +b.displayOrder ? -1 : 1);
-    });
-    // subscribe to data values
-    this.dataValueQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(dataValues => {
-      this.dataValues = [];
-      dataValues.forEach(dv => {
-        this.dataValues.push({ ... dv });
       });
-    });
-    this.cardQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(cards => {
-      this.cardList = cards;
-    });
+    // subscribe to the active MSEL
+    (this.mselQuery.selectActive() as Observable<MselPlus>)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((msel) => {
+        if (msel && this.msel.id !== msel.id) {
+          this.msel = this.getEditableMsel(msel) as MselPlus;
+        }
+      });
+    // subscribe to data fields
+    this.dataFieldQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((dataFields) => {
+        this.getSortedDataFields(dataFields);
+      });
+    // subscribe to data values
+    this.dataValueQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((dataValues) => {
+        this.dataValues = [];
+        dataValues.forEach((dv) => {
+          this.dataValues.push({ ...dv });
+        });
+      });
+    this.cardQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((cards) => {
+        this.cardList = cards;
+      });
 
-    (this.scenarioEventQuery.selectAll()).pipe(takeUntil(this.unsubscribe$)).subscribe(scenarioEvents => {
-      this.mselScenarioEvents = this.getEditableScenarioEvents(scenarioEvents as ScenarioEventPlus[]);
-      if (scenarioEvents && scenarioEvents.length > 0) {
-        this.moveAndGroupNumbers = this.scenarioEventDataService.getMoveAndGroupNumbers(this.mselScenarioEvents, this.moveList);
-        this.filteredScenarioEventList = this.getFilteredScenarioEvents();
-        this.sortedScenarioEvents = this.getSortedScenarioEvents(this.filteredScenarioEventList);
-      }
-    });
-    this.moveQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(moves => {
-      this.moveList = moves.sort((a, b) => +a.moveNumber < +b.moveNumber ? -1 : 1);
-      this.moveAndGroupNumbers = this.scenarioEventDataService.getMoveAndGroupNumbers(this.mselScenarioEvents, this.moveList);
-    });
+    this.scenarioEventQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((scenarioEvents) => {
+        this.mselScenarioEvents = this.getEditableScenarioEvents(
+          scenarioEvents as ScenarioEventPlus[]
+        );
+        if (scenarioEvents && scenarioEvents.length > 0) {
+          this.moveAndGroupNumbers =
+            this.scenarioEventDataService.getMoveAndGroupNumbers(
+              this.mselScenarioEvents,
+              this.moveList
+            );
+          this.filteredScenarioEventList = this.getFilteredScenarioEvents();
+          this.sortedScenarioEvents = this.getSortedScenarioEvents(
+            this.filteredScenarioEventList
+          );
+        }
+      });
+    this.moveQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((moves) => {
+        this.moveList = moves.sort((a, b) =>
+          +a.moveNumber < +b.moveNumber ? -1 : 1
+        );
+        this.moveAndGroupNumbers =
+          this.scenarioEventDataService.getMoveAndGroupNumbers(
+            this.mselScenarioEvents,
+            this.moveList
+          );
+      });
   }
 
-  getEditableMsel (msel: MselPlus): MselPlus {
+  getEditableMsel(msel: MselPlus): MselPlus {
     const editableMsel = new MselPlus();
     Object.assign(editableMsel, msel);
-    editableMsel.teams = editableMsel.teams.slice(0).sort((a, b) => a.shortName.toLowerCase() < b.shortName.toLowerCase() ? -1 : 1);
+    editableMsel.teams = editableMsel.teams
+      .slice(0)
+      .sort((a, b) =>
+        a.shortName.toLowerCase() < b.shortName.toLowerCase() ? -1 : 1
+      );
 
     return editableMsel;
   }
@@ -181,23 +222,26 @@ export class MselPlaybookComponent{
   getSortedDataFields(dataFields: DataField[]) {
     if (dataFields) {
       this.sortedDataFields = dataFields
-        .filter(df => df.onScenarioEventList)
-        .sort((a, b) => +a.displayOrder > +b.displayOrder ? 1 : -1);
-      this.allDataFields = dataFields
-        .sort((a, b) => +a.displayOrder > +b.displayOrder ? 1 : -1);
+        .filter((df) => df.onScenarioEventList)
+        .sort((a, b) => (+a.displayOrder > +b.displayOrder ? 1 : -1));
+      this.allDataFields = dataFields.sort((a, b) =>
+        +a.displayOrder > +b.displayOrder ? 1 : -1
+      );
     }
     // create date form controls
-    this.allDataFields.forEach(df => {
+    this.allDataFields.forEach((df) => {
       if (df.dataType === DataFieldType.DateTime) {
         this.dateFormControls[df.id] = new UntypedFormControl();
       }
     });
   }
 
-  getEditableScenarioEvents(scenarioEvents: ScenarioEventPlus[]): ScenarioEventPlus[] {
+  getEditableScenarioEvents(
+    scenarioEvents: ScenarioEventPlus[]
+  ): ScenarioEventPlus[] {
     const editableList: ScenarioEventPlus[] = [];
-    scenarioEvents.forEach(scenarioEvent => {
-      const newScenarioEvent = { ...scenarioEvent};
+    scenarioEvents.forEach((scenarioEvent) => {
+      const newScenarioEvent = { ...scenarioEvent };
       editableList.push(newScenarioEvent);
     });
 
@@ -207,27 +251,36 @@ export class MselPlaybookComponent{
   getFilteredScenarioEvents(): ScenarioEventPlus[] {
     const mselScenarioEvents: ScenarioEventPlus[] = [];
     if (this.mselScenarioEvents) {
-      this.mselScenarioEvents.forEach(se => {
+      this.mselScenarioEvents.forEach((se) => {
         if (se.mselId === this.msel.id) {
-          mselScenarioEvents.push({... se});
+          mselScenarioEvents.push({ ...se });
         }
       });
-      if (mselScenarioEvents && mselScenarioEvents.length > 0 && this.filterString) {
+      if (
+        mselScenarioEvents &&
+        mselScenarioEvents.length > 0 &&
+        this.filterString
+      ) {
         const filterString = this.filterString.toLowerCase();
         const that = this;
-        const filteredScenarioEvents = mselScenarioEvents
-          .filter((a) =>
-            this.sortedDataFields.some(df =>
-              that.getDataValue(a, df.name).value?.toLowerCase().includes(filterString)
-            )
-          );
+        const filteredScenarioEvents = mselScenarioEvents.filter((a) =>
+          this.sortedDataFields.some((df) =>
+            that
+              .getDataValue(a, df.name)
+              .value?.toLowerCase()
+              .includes(filterString)
+          )
+        );
         return filteredScenarioEvents;
       }
     }
     return mselScenarioEvents;
   }
 
-  getDataValue(scenarioEvent: ScenarioEventPlus, dataFieldName: string): DataValuePlus {
+  getDataValue(
+    scenarioEvent: ScenarioEventPlus,
+    dataFieldName: string
+  ): DataValuePlus {
     if (!(this.msel && scenarioEvent && scenarioEvent.id)) {
       return this.blankDataValue;
     }
@@ -235,10 +288,15 @@ export class MselPlaybookComponent{
     if (!dataFieldId) {
       return this.blankDataValue;
     }
-    let dataValuePlus = this.dataValues.find(dv =>
-      dv.dataFieldId === dataFieldId && dv.scenarioEventId === scenarioEvent.id) as DataValuePlus;
+    let dataValuePlus = this.dataValues.find(
+      (dv) =>
+        dv.dataFieldId === dataFieldId &&
+        dv.scenarioEventId === scenarioEvent.id
+    ) as DataValuePlus;
     if (dataValuePlus) {
-      dataValuePlus.valueArray = dataValuePlus.value ? dataValuePlus.value.split(', ') : [];
+      dataValuePlus.valueArray = dataValuePlus.value
+        ? dataValuePlus.value.split(', ')
+        : [];
     } else {
       dataValuePlus = this.blankDataValue;
     }
@@ -246,32 +304,46 @@ export class MselPlaybookComponent{
   }
 
   getDataFieldIdByName(scenarioEvent: ScenarioEventPlus, name: string): string {
-    const dataField = this.allDataFields.find(df => df.name.toLowerCase() === name.toLowerCase());
+    const dataField = this.allDataFields.find(
+      (df) => df.name.toLowerCase() === name.toLowerCase()
+    );
     return dataField ? dataField.id : '';
   }
 
-  getSortedScenarioEvents(scenarioEvents: ScenarioEventPlus[]): ScenarioEventPlus[] {
+  getSortedScenarioEvents(
+    scenarioEvents: ScenarioEventPlus[]
+  ): ScenarioEventPlus[] {
     let sortedScenarioEvents: ScenarioEventPlus[];
     if (scenarioEvents) {
       if (scenarioEvents.length > 0 && this.sort && this.sort.direction) {
-        sortedScenarioEvents = (scenarioEvents as ScenarioEventPlus[])
-          .sort((a: ScenarioEventPlus, b: ScenarioEventPlus) => this.sortScenarioEvents(a, b));
+        sortedScenarioEvents = (scenarioEvents as ScenarioEventPlus[]).sort(
+          (a: ScenarioEventPlus, b: ScenarioEventPlus) =>
+            this.sortScenarioEvents(a, b)
+        );
       } else {
-        sortedScenarioEvents = (scenarioEvents as ScenarioEventPlus[])
-          .sort((a, b) => +a.deltaSeconds > +b.deltaSeconds ? 1 : -1);
+        sortedScenarioEvents = (scenarioEvents as ScenarioEventPlus[]).sort(
+          (a, b) => (+a.deltaSeconds > +b.deltaSeconds ? 1 : -1)
+        );
       }
     }
     return sortedScenarioEvents;
   }
 
-  private sortScenarioEvents(a: ScenarioEventPlus, b: ScenarioEventPlus): number {
+  private sortScenarioEvents(
+    a: ScenarioEventPlus,
+    b: ScenarioEventPlus
+  ): number {
     const dir = this.sort.direction === 'desc' ? -1 : 1;
     if (!this.sort.direction || this.sort.active === 'deltaSeconds') {
       this.sort = { active: 'deltaSeconds', direction: 'asc' };
       return +a.deltaSeconds < +b.deltaSeconds ? -dir : dir;
     } else {
-      const aValue = this.getDataValue(a, this.sort.active).value?.toString().toLowerCase();
-      const bValue = this.getDataValue(b, this.sort.active).value?.toString().toLowerCase();
+      const aValue = this.getDataValue(a, this.sort.active)
+        .value?.toString()
+        .toLowerCase();
+      const bValue = this.getDataValue(b, this.sort.active)
+        .value?.toString()
+        .toLowerCase();
       if (aValue === bValue) {
         return +a.deltaSeconds < +b.deltaSeconds ? -dir : dir;
       } else {
@@ -284,11 +356,15 @@ export class MselPlaybookComponent{
     if (!(this.msel && scenarioEvent && scenarioEvent.id)) {
       return '';
     }
-    const dataField = this.allDataFields.find(df => df.name === columnName);
+    const dataField = this.allDataFields.find((df) => df.name === columnName);
     if (!dataField) {
       return '';
     }
-    const dataValue = this.dataValues.find(dv => dv.dataFieldId === dataField.id && dv.scenarioEventId === scenarioEvent.id);
+    const dataValue = this.dataValues.find(
+      (dv) =>
+        dv.dataFieldId === dataField.id &&
+        dv.scenarioEventId === scenarioEvent.id
+    );
 
     if (dataValue) {
       if (dataField.dataType === 'Card') {
@@ -302,18 +378,22 @@ export class MselPlaybookComponent{
   }
 
   getScenarioEventById(id: string): ScenarioEventPlus | undefined {
-    return this.mselScenarioEvents.find(se => se.id === id);
+    return this.mselScenarioEvents.find((se) => se.id === id);
   }
 
   getScenarioEventTitle(scenarioEvent: ScenarioEventPlus): string {
     if (!scenarioEvent) {
       return '';
     }
-    const titleField = this.allDataFields.find(df => df.name === 'Title');
+    const titleField = this.allDataFields.find((df) => df.name === 'Title');
     if (!titleField) {
       return '';
     }
-    const titleDataValue = this.dataValues.find(dv => dv.dataFieldId === titleField.id && dv.scenarioEventId === scenarioEvent.id);
+    const titleDataValue = this.dataValues.find(
+      (dv) =>
+        dv.dataFieldId === titleField.id &&
+        dv.scenarioEventId === scenarioEvent.id
+    );
     return titleDataValue ? titleDataValue.value : '';
   }
 
@@ -330,7 +410,7 @@ export class MselPlaybookComponent{
   }
 
   getCardNameById(cardId: string): string {
-    const card = this.cardList.find(c => c.id === cardId);
+    const card = this.cardList.find((c) => c.id === cardId);
     return card ? card.name : 'Unknown';
   }
 

--- a/src/app/components/msel/msel.component.html
+++ b/src/app/components/msel/msel.component.html
@@ -155,6 +155,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
         [loggedInUserId]="loggedInUserId"
         [isContentDeveloper]="isContentDeveloper"
         [showTemplates]="false"
+        [userTheme]="userTheme$ | async"
       ></app-data-field-list>
       <app-organization-list
         *ngIf="selectedTab === 'Organizations'"

--- a/src/app/components/scenario-event-edit-dialog/scenario-event-edit-dialog.component.html
+++ b/src/app/components/scenario-event-edit-dialog/scenario-event-edit-dialog.component.html
@@ -231,7 +231,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
             [value]="getDataValue(df.name).valueArray"
             [disabled]="!data.isEditor"
           >
-            <mat-option *ngFor="let dataOption of getDataOptions(df.id)" [value]="dataOption.optionValue">
+            <mat-option *ngFor="let dataOption of df.dataOptions" [value]="dataOption.optionValue">
               {{ dataOption.optionName }}
             </mat-option>
           </mat-select>
@@ -244,7 +244,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
             [(ngModel)]="getDataValue(df.name).value"
             [disabled]="!data.isEditor"
           >
-            <mat-option *ngFor="let dataOption of getDataOptions(df.id)" [value]="dataOption.optionValue">
+            <mat-option *ngFor="let dataOption of df.dataOptions" [value]="dataOption.optionValue">
               {{ dataOption.optionName }}
             </mat-option>
           </mat-select>

--- a/src/app/components/scenario-event-edit-dialog/scenario-event-edit-dialog.component.ts
+++ b/src/app/components/scenario-event-edit-dialog/scenario-event-edit-dialog.component.ts
@@ -23,7 +23,7 @@ import { AngularEditorConfig } from '@kolkov/angular-editor';
 })
 export class ScenarioEventEditDialogComponent implements OnDestroy, OnInit {
   @Output() editComplete = new EventEmitter<any>();
-  sort: Sort = {active: '', direction: ''};
+  sort: Sort = { active: '', direction: '' };
   sortedScenarioEvents: ScenarioEventPlus[] = [];
   newScenarioEvent: ScenarioEventPlus;
   isAddingScenarioEvent = false;
@@ -45,18 +45,16 @@ export class ScenarioEventEditDialogComponent implements OnDestroy, OnInit {
     defaultFontName: '',
     defaultFontSize: '',
     fonts: [
-      {class: 'arial', name: 'Arial'},
-      {class: 'times-new-roman', name: 'Times New Roman'},
-      {class: 'calibri', name: 'Calibri'},
-      {class: 'comic-sans-ms', name: 'Comic Sans MS'}
+      { class: 'arial', name: 'Arial' },
+      { class: 'times-new-roman', name: 'Times New Roman' },
+      { class: 'calibri', name: 'Calibri' },
+      { class: 'comic-sans-ms', name: 'Comic Sans MS' },
     ],
     uploadUrl: '',
     uploadWithCredentials: false,
     sanitize: true,
     toolbarPosition: 'top',
-    toolbarHiddenButtons: [
-      ['backgroundColor']
-    ]
+    toolbarHiddenButtons: [['backgroundColor']],
   };
   viewConfig: AngularEditorConfig = {
     editable: false,
@@ -75,21 +73,32 @@ export class ScenarioEventEditDialogComponent implements OnDestroy, OnInit {
   };
   dataType: typeof DataFieldType = DataFieldType;
 
-  itemStatus = [MselItemStatus.Pending, MselItemStatus.Entered, MselItemStatus.Approved, MselItemStatus.Complete, MselItemStatus.Deployed, MselItemStatus.Archived];
-  mselRole = { Owner: MselRole.Owner, Approver: MselRole.Approver, Editor: MselRole.Editor};
+  itemStatus = [
+    MselItemStatus.Pending,
+    MselItemStatus.Entered,
+    MselItemStatus.Approved,
+    MselItemStatus.Complete,
+    MselItemStatus.Deployed,
+    MselItemStatus.Archived,
+  ];
+  mselRole = {
+    Owner: MselRole.Owner,
+    Approver: MselRole.Approver,
+    Editor: MselRole.Editor,
+  };
   toOrgList: string[] = [];
   sortedMselTeams: Team[] = [];
   blankDataValue = {
     id: '',
     value: '',
-    valueArray: []
+    valueArray: [],
   } as DataValuePlus;
   scenarioEventBackgroundColors: Array<string>;
   sortedDataFields: DataField[] = [];
   selectedTab = 0;
   private tabSections = new Map([
     ['default', 0],
-    ['advanced', 1]
+    ['advanced', 1],
   ]);
   private tabCount = 2;
   currentFilterBy = 'default';
@@ -120,23 +129,23 @@ export class ScenarioEventEditDialogComponent implements OnDestroy, OnInit {
     return item.id;
   }
 
-  getDataOptions(dataFieldId: string) {
-    return this.data.dataOptions.filter(x => x.dataFieldId === dataFieldId);
-  }
-
   getDataValue(dataFieldName: string): DataValuePlus {
     const dataFieldId = this.getDataFieldIdByName(dataFieldName);
     if (!dataFieldId) {
       return this.blankDataValue;
     }
-    const dataValue = this.data.scenarioEvent.dataValues.find(dv => dv.dataFieldId === dataFieldId);
-    return dataValue ? dataValue as DataValuePlus : this.blankDataValue;
+    const dataValue = this.data.scenarioEvent.dataValues.find(
+      (dv) => dv.dataFieldId === dataFieldId
+    );
+    return dataValue ? (dataValue as DataValuePlus) : this.blankDataValue;
   }
 
   setDataValue(dataFieldName: string, value: string) {
     const dataFieldId = this.getDataFieldIdByName(dataFieldName);
     if (dataFieldId) {
-      const dataValue = this.data.scenarioEvent.dataValues.find(dv => dv.dataFieldId === dataFieldId);
+      const dataValue = this.data.scenarioEvent.dataValues.find(
+        (dv) => dv.dataFieldId === dataFieldId
+      );
       dataValue.value = value;
     }
   }
@@ -150,7 +159,9 @@ export class ScenarioEventEditDialogComponent implements OnDestroy, OnInit {
   }
 
   getDataFieldIdByName(name: string): string {
-    const dataField = this.data.dataFields.find(df => df.name.toLowerCase() === name.toLowerCase());
+    const dataField = this.data.dataFields.find(
+      (df) => df.name.toLowerCase() === name.toLowerCase()
+    );
     return dataField ? dataField.id : '';
   }
 
@@ -171,7 +182,7 @@ export class ScenarioEventEditDialogComponent implements OnDestroy, OnInit {
     } else {
       this.editComplete.emit({
         saveChanges: saveChanges,
-        scenarioEvent: this.data.scenarioEvent
+        scenarioEvent: this.data.scenarioEvent,
       });
     }
   }
@@ -186,16 +197,22 @@ export class ScenarioEventEditDialogComponent implements OnDestroy, OnInit {
     let filteredList = [];
     switch (filter) {
       case 'default':
-        filteredList = this.data.dataFields.filter(x => !x.isInitiallyHidden);
+        filteredList = this.data.dataFields.filter((x) => !x.isInitiallyHidden);
         break;
       case 'gallery':
-        filteredList = this.data.dataFields.filter(x => !!x.galleryArticleParameter);
+        filteredList = this.data.dataFields.filter(
+          (x) => !!x.galleryArticleParameter
+        );
         break;
       case 'advanced':
-        filteredList = this.data.dataFields.filter(x => x.isInitiallyHidden && !x.galleryArticleParameter);
+        filteredList = this.data.dataFields.filter(
+          (x) => x.isInitiallyHidden && !x.galleryArticleParameter
+        );
         break;
     }
-    filteredList =  filteredList.sort((a, b) => +a.displayOrder < +b.displayOrder ? -1 : 1);
+    filteredList = filteredList.sort((a, b) =>
+      +a.displayOrder < +b.displayOrder ? -1 : 1
+    );
     return filteredList;
   }
 

--- a/src/app/components/scenario-event-list/scenario-event-list.component.html
+++ b/src/app/components/scenario-event-list/scenario-event-list.component.html
@@ -460,7 +460,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
                     placeholder="None"
                     [value]="getDataValue(item, df.name).valueArray"
                   >
-                    <mat-option *ngFor="let dataOption of getDataOptions(df.id)" [value]="dataOption.optionValue">
+                    <mat-option *ngFor="let dataOption of df.dataOptions" [value]="dataOption.optionValue">
                         {{ dataOption.optionName }}
                       </mat-option>
                   </mat-select>
@@ -485,7 +485,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
                     placeholder=" - - - "
                   >
                     <mat-option value=""> - - - </mat-option>
-                    <mat-option *ngFor="let dataOption of getDataOptions(df.id)" [value]="dataOption.optionValue">{{ dataOption.optionName }}</mat-option>
+                    <mat-option *ngFor="let dataOption of df.dataOptions" [value]="dataOption.optionValue">{{ dataOption.optionName }}</mat-option>
                   </mat-select>
                 </div>
               </td>

--- a/src/app/components/scenario-event-list/scenario-event-list.component.ts
+++ b/src/app/components/scenario-event-list/scenario-event-list.component.ts
@@ -20,7 +20,6 @@ import {
   Card,
   DataField,
   DataFieldType,
-  DataOption,
   DataValue,
   MselItemStatus,
   Move,
@@ -51,7 +50,6 @@ import { DataValueQuery } from 'src/app/data/data-value/data-value.query';
 import { DialogService } from 'src/app/services/dialog/dialog.service';
 import { v4 as uuidv4 } from 'uuid';
 import { DataFieldQuery } from 'src/app/data/data-field/data-field.query';
-import { DataOptionQuery } from 'src/app/data/data-option/data-option.query';
 import { TeamQuery } from 'src/app/data/team/team.query';
 import { UIDataService } from 'src/app/data/ui/ui-data.service';
 import { AngularEditorConfig } from '@kolkov/angular-editor';
@@ -80,7 +78,6 @@ export class ScenarioEventListComponent
   mselUsers: User[] = [];
   viewIndex = new ScenarioEventViewIndexing();
 
-  sortedDataOptions: DataOption[] = [];
   allDataFields: DataField[] = [];
   expandedScenarioEventId = '';
   expandedMoreScenarioEventIds: string[] = [];
@@ -173,7 +170,6 @@ export class ScenarioEventListComponent
     public dialogService: DialogService,
     public dialog: MatDialog,
     private dataFieldQuery: DataFieldQuery,
-    private dataOptionQuery: DataOptionQuery,
     private dataValueDataService: DataValueDataService,
     private dataValueQuery: DataValueQuery,
     private teamQuery: TeamQuery,
@@ -200,15 +196,6 @@ export class ScenarioEventListComponent
         this.scenarioEventDataService.updateScenarioEventViewDataFields(this);
         this.scenarioEventDataService.updateScenarioEventViewDisplayedEvents(
           this
-        );
-      });
-    // subscribe to the data options
-    this.dataOptionQuery
-      .selectAll()
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe((dataOptions) => {
-        this.sortedDataOptions = dataOptions.sort((a, b) =>
-          +a.displayOrder < +b.displayOrder ? -1 : 1
         );
       });
     // subscribe to data values
@@ -351,10 +338,6 @@ export class ScenarioEventListComponent
         this.dateFormControls[df.id] = new UntypedFormControl();
       }
     });
-  }
-
-  getDataOptions(dataFieldId: string) {
-    return this.sortedDataOptions.filter((x) => x.dataFieldId === dataFieldId);
   }
 
   getMselUsers(): User[] {
@@ -634,7 +617,6 @@ export class ScenarioEventListComponent
       data: {
         scenarioEvent: scenarioEvent,
         dataFields: this.allDataFields,
-        dataOptions: this.sortedDataOptions,
         organizationList: this.getSortedOrganizationOptions(),
         teamList: this.msel.teams,
         moveList: this.moveList,


### PR DESCRIPTION
Added the ability to drag and drop data fields to change their order on the page for MSEL data fields. This is not enabled on the template data fields page because it doesn't make sense there.

The MR also completed the implementation of sorting on both Data Fields pages and removed the DataOption queries that are no longer needed.