### PR TITLE
Added ability for player to control the theme of the embedded event management page

### DIFF
--- a/src/app/components/admin/admin-container/admin-container.component.ts
+++ b/src/app/components/admin/admin-container/admin-container.component.ts
@@ -68,7 +68,7 @@ export class AdminContainerComponent implements OnDestroy, OnInit {
     private uiDataService: UIDataService
   ) {
     this.theme$ = this.authQuery.userTheme$;
-    this.hideTopbar = this.inIframe();
+    this.hideTopbar = this.uiDataService.inIframe();
     // subscribe to the logged in user
     this.userDataService.loggedInUser
       .pipe(takeUntil(this.unsubscribe$))
@@ -145,14 +145,6 @@ export class AdminContainerComponent implements OnDestroy, OnInit {
 
   logout() {
     this.userDataService.logout();
-  }
-
-  inIframe() {
-    try {
-      return window.self !== window.top;
-    } catch (e) {
-      return true;
-    }
   }
 
   getApiVersion() {

--- a/src/app/components/inject-page/inject-page.component.ts
+++ b/src/app/components/inject-page/inject-page.component.ts
@@ -46,6 +46,7 @@ import { Sort } from '@angular/material/sort';
 import { Component, Input } from '@angular/core';
 import { AngularEditorConfig } from '@kolkov/angular-editor';
 import { CardQuery } from 'src/app/data/card/card.query';
+import { UIDataService } from 'src/app/data/ui/ui-data.service';
 
 @Component({
   selector: 'app-inject-page',
@@ -138,8 +139,10 @@ export class InjectPageComponent {
     private dataValueQuery: DataValueQuery,
     private scenarioEventQuery: ScenarioEventQuery,
     private cardQuery: CardQuery,
-    private activatedRoute: ActivatedRoute
+    private activatedRoute: ActivatedRoute,
+    private uiDataService: UIDataService
   ) {
+    this.hideTopbar = this.uiDataService.inIframe();
     // set image
     this.imageFilePath = this.settingsService.settings.AppTopBarImage.replace(
       'white',

--- a/src/app/components/landing/dashboard/dashboard.component.html
+++ b/src/app/components/landing/dashboard/dashboard.component.html
@@ -5,6 +5,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
 -->
 <div class="top-container background">
   <app-topbar
+    *ngIf="!hideTopbar"
     [title]="topbarText"
     [topbarView]="TopbarView.BLUEPRINT_HOME"
     [topbarColor]="topbarColor"
@@ -64,4 +65,3 @@ project root for license information or contact permission@sei.cmu.edu for full 
 
   </div>
 </div>
-

--- a/src/app/components/landing/dashboard/dashboard.component.ts
+++ b/src/app/components/landing/dashboard/dashboard.component.ts
@@ -16,6 +16,7 @@ import { MselDataService } from 'src/app/data/msel/msel-data.service';
 import { User } from 'src/app/generated/blueprint.api';
 import { TopbarView } from '../../shared/top-bar/topbar.models';
 import { Title } from '@angular/platform-browser';
+import { UIDataService } from 'src/app/data/ui/ui-data.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -45,10 +46,15 @@ export class DashboardComponent implements OnDestroy {
     private settingsService: ComnSettingsService,
     private mselDataService: MselDataService,
     private router: Router,
-    private titleService: Title
+    private titleService: Title,
+    private uiDataService: UIDataService
   ) {
+    this.hideTopbar = this.uiDataService.inIframe();
     // set image
-    this.imageFilePath = this.settingsService.settings.AppTopBarImage.replace('white', 'blue');
+    this.imageFilePath = this.settingsService.settings.AppTopBarImage.replace(
+      'white',
+      'blue'
+    );
     this.titleService.setTitle(this.appTitle);
     // Set the display settings from config file
     this.topbarColor = this.settingsService.settings.AppTopBarHexColor
@@ -58,23 +64,34 @@ export class DashboardComponent implements OnDestroy {
       ? this.settingsService.settings.AppTopBarHexTextColor
       : this.topbarTextColor;
     // subscribe to users
-    this.userDataService.users.pipe(takeUntil(this.unsubscribe$)).subscribe(users => {
-      this.userList = users;
-    });
+    this.userDataService.users
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((users) => {
+        this.userList = users;
+      });
     // load the users
     this.userDataService.getUsersFromApi();
     // load the launch MSELs
-    this.mselDataService.getMyLaunchMsels().pipe(take(1)).subscribe((msels) => {
-      this.launchMselList = msels;
-    });
+    this.mselDataService
+      .getMyLaunchMsels()
+      .pipe(take(1))
+      .subscribe((msels) => {
+        this.launchMselList = msels;
+      });
     // load the join MSELs
-    this.mselDataService.getMyJoinMsels().pipe(take(1)).subscribe((msels) => {
-      this.joinMselList = msels;
-    });
+    this.mselDataService
+      .getMyJoinMsels()
+      .pipe(take(1))
+      .subscribe((msels) => {
+        this.joinMselList = msels;
+      });
     // load the build MSELs
-    this.mselDataService.getMyBuildMsels().pipe(take(1)).subscribe((msels) => {
-      this.buildMselList = msels;
-    });
+    this.mselDataService
+      .getMyBuildMsels()
+      .pipe(take(1))
+      .subscribe((msels) => {
+        this.buildMselList = msels;
+      });
   }
 
   topBarNavigate(url): void {

--- a/src/app/components/landing/join/join.component.html
+++ b/src/app/components/landing/join/join.component.html
@@ -5,6 +5,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
 -->
 <div class="top-container background">
   <app-topbar
+    *ngIf="!hideTopbar"
     [title]="topbarText"
     [topbarView]="TopbarView.BLUEPRINT_HOME"
     [topbarColor]="topbarColor"
@@ -62,4 +63,3 @@ project root for license information or contact permission@sei.cmu.edu for full 
     </mat-card>
   </div>
 </div>
-

--- a/src/app/components/landing/manage/manage.component.ts
+++ b/src/app/components/landing/manage/manage.component.ts
@@ -17,9 +17,9 @@ import { ErrorService } from 'src/app/services/error/error.service';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { DialogService } from 'src/app/services/dialog/dialog.service';
 import { InvitationDataService } from 'src/app/data/invitation/invitation-data.service';
-import { InvitationQuery } from 'src/app/data/invitation/invitation.query';
 import { TeamDataService } from 'src/app/data/team/team-data.service';
 import { MselItemStatus } from 'src/app/generated/blueprint.api';
+import { UIDataService } from 'src/app/data/ui/ui-data.service';
 
 @Component({
   selector: 'app-manage',
@@ -55,11 +55,15 @@ export class ManageComponent implements OnDestroy {
     private titleService: Title,
     public dialog: MatDialog,
     public dialogService: DialogService,
-    private errorService: ErrorService
+    private errorService: ErrorService,
+    private uiDataService: UIDataService
   ) {
-    this.hideTopbar = this.inIframe();
+    this.hideTopbar = this.uiDataService.inIframe();
     // set image
-    this.imageFilePath = this.settingsService.settings.AppTopBarImage.replace('white', 'blue');
+    this.imageFilePath = this.settingsService.settings.AppTopBarImage.replace(
+      'white',
+      'blue'
+    );
     this.titleService.setTitle(this.appTitle);
     // Set the display settings from config file
     this.topbarColor = this.settingsService.settings.AppTopBarHexColor
@@ -69,31 +73,39 @@ export class ManageComponent implements OnDestroy {
       ? this.settingsService.settings.AppTopBarHexTextColor
       : this.topbarTextColor;
     // subscribe to route changes
-    this.activatedRoute.queryParamMap.pipe(takeUntil(this.unsubscribe$)).subscribe(params => {
-      const mselId = params.get('msel');
-      if (mselId) {
-        // reset and subscribe to the msel
-        this.unsubscribe$.next(null);
-        this.unsubscribe$.complete();
-        this.unsubscribe$ = new Subject();
-        this.mselDataService.setActive(mselId);
-        (this.mselQuery.selectActive() as Observable<MselPlus>).pipe(takeUntil(this.unsubscribe$)).subscribe( msel => {
-          if (msel) {
-            if (msel.status !== MselItemStatus.Deployed) {
-              const url = this.settingsService.settings.OIDCSettings.post_logout_redirect_uri;
-              window.top.location.href = url;
-            }
-            this.msel = Object.assign(this.msel, msel);
-            this.startTime = new Date(this.msel.startTime);
-            this.endTime = new Date(this.startTime.getTime() + (this.msel.durationSeconds * 1000));
-            this.invitationDataService.loadByMsel(msel.id);
-            this.teamDataService.loadByMsel(mselId);
-          }
-        });
-        // set appTitle and topbarText for top level
-        this.mselDataService.loadById(mselId);
-      }
-    });
+    this.activatedRoute.queryParamMap
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((params) => {
+        const mselId = params.get('msel');
+        if (mselId) {
+          // reset and subscribe to the msel
+          this.unsubscribe$.next(null);
+          this.unsubscribe$.complete();
+          this.unsubscribe$ = new Subject();
+          this.mselDataService.setActive(mselId);
+          (this.mselQuery.selectActive() as Observable<MselPlus>)
+            .pipe(takeUntil(this.unsubscribe$))
+            .subscribe((msel) => {
+              if (msel) {
+                if (msel.status !== MselItemStatus.Deployed) {
+                  const url =
+                    this.settingsService.settings.OIDCSettings
+                      .post_logout_redirect_uri;
+                  window.top.location.href = url;
+                }
+                this.msel = Object.assign(this.msel, msel);
+                this.startTime = new Date(this.msel.startTime);
+                this.endTime = new Date(
+                  this.startTime.getTime() + this.msel.durationSeconds * 1000
+                );
+                this.invitationDataService.loadByMsel(msel.id);
+                this.teamDataService.loadByMsel(mselId);
+              }
+            });
+          // set appTitle and topbarText for top level
+          this.mselDataService.loadById(mselId);
+        }
+      });
     // subscribe to the logged in user
     this.userDataService.loggedInUser
       .pipe(takeUntil(this.unsubscribe$))
@@ -110,10 +122,7 @@ export class ManageComponent implements OnDestroy {
 
   endEvent() {
     this.dialogService
-      .confirm(
-        'End the Event',
-        'Are you sure that you want to end this event?'
-      )
+      .confirm('End the Event', 'Are you sure that you want to end this event?')
       .subscribe((result) => {
         if (result['confirm']) {
           this.mselDataService.archive(this.msel.id);
@@ -127,21 +136,15 @@ export class ManageComponent implements OnDestroy {
 
   updateEndTime() {
     if (this.endTime) {
-      this.msel.durationSeconds = Math.round((this.endTime.getTime() - this.startTime.getTime()) / 1000);
+      this.msel.durationSeconds = Math.round(
+        (this.endTime.getTime() - this.startTime.getTime()) / 1000
+      );
       this.mselDataService.updateMsel(this.msel);
     }
   }
 
   logout() {
     this.userDataService.logout();
-  }
-
-  inIframe() {
-    try {
-      return window.self !== window.top;
-    } catch (e) {
-      return true;
-    }
   }
 
   ngOnDestroy() {

--- a/src/app/components/shared/top-bar/topbar.component.ts
+++ b/src/app/components/shared/top-bar/topbar.component.ts
@@ -57,7 +57,6 @@ export class TopbarComponent implements OnInit, OnDestroy {
       takeUntil(this.unsubscribe$)
     );
     this.theme$ = this.authQuery.userTheme$;
-    this.authService.setUserTheme(<Theme>this.uiDataService.getTheme() || Theme.LIGHT);
   }
 
   setTeamFn(id: string) {
@@ -69,7 +68,6 @@ export class TopbarComponent implements OnInit, OnDestroy {
   themeFn(event) {
     const theme = event.checked ? Theme.DARK : Theme.LIGHT;
     this.authService.setUserTheme(theme);
-    this.uiDataService.setTheme(theme);
   }
   editFn(event) {
     this.editView.emit(event);

--- a/src/app/data/ui/ui-data.service.ts
+++ b/src/app/data/ui/ui-data.service.ts
@@ -7,7 +7,6 @@
 import { Injectable } from '@angular/core';
 
 export class UIState {
-  selectedTheme = '';
   selectedMselTab = '';
   selectedAdminTab = '';
   expandedItems: string[] = [];
@@ -29,7 +28,7 @@ export class UIDataService {
   //
   // Item Expansion
   isItemExpanded(id: string): boolean {
-    return this.uiState.expandedItems.some(ei => ei === id);
+    return this.uiState.expandedItems.some((ei) => ei === id);
   }
 
   setItemExpanded(id: string) {
@@ -80,15 +79,12 @@ export class UIDataService {
   }
   // end MSEL tab section
 
-  //
-  // theme section
-  setTheme(theme: string) {
-    this.uiState.selectedTheme = theme;
-    this.saveChanges();
-  }
-
-  getTheme(): string {
-    return this.uiState.selectedTheme;
+  inIframe() {
+    try {
+      return window.self !== window.top;
+    } catch (e) {
+      return true;
+    }
   }
   // end theme section
 

--- a/src/app/data/ui/ui-data.service.ts
+++ b/src/app/data/ui/ui-data.service.ts
@@ -86,7 +86,6 @@ export class UIDataService {
       return true;
     }
   }
-  // end theme section
 
   //
   // real time vs offset time display section


### PR DESCRIPTION
This MR adds the {theme} parameter to the event management page so that player can manage its theme when it is embedded. Also, removed the redundant ui selected theme setting because that preference is now saved as part of the akita datastore cache. Removed top component from all pages when embedded in another app like player since the containing app should own that menu.