### PR TITLE
Add integration status component and push/pull workflow UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blueprint-ui",
-  "version": "1.7.11",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blueprint-ui",
-      "version": "1.7.11",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^21.2.1",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,6 +16,7 @@ import { LaunchComponent } from './components/landing/launch/launch.component';
 import { ManageComponent } from './components/landing/manage/manage.component';
 import { StarterComponent } from './components/starter/starter.component';
 import { EventDetailPageComponent } from './components/event-detail-page/event-detail-page.component';
+import { IntegrationInProgressGuard } from './services/integration-in-progress.guard';
 
 export const ROUTES: Routes = [
   {
@@ -27,6 +28,7 @@ export const ROUTES: Routes = [
     path: 'build',
     component: HomeAppComponent,
     canActivate: [ComnAuthGuardService],
+    canDeactivate: [IntegrationInProgressGuard],
   },
   {
     path: 'join',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -100,6 +100,7 @@ import { MoveListComponent } from './components/move-list/move-list.component';
 import { MselComponent } from './components/msel/msel.component';
 import { MselContributorsComponent } from './components/msel-contributors/msel-contributors.component';
 import { MselInfoComponent } from './components/msel-info/msel-info.component';
+import { IntegrationStatusComponent } from './components/integration-status/integration-status.component';
 import { MselListComponent } from './components/msel-list/msel-list.component';
 import { MselPageComponent } from './components/msel-page/msel-page.component';
 import { MselTeamsComponent } from './components/msel-teams/msel-teams.component';
@@ -190,6 +191,7 @@ export const appConfig: ApplicationConfig = {
     MselComponent,
     MselContributorsComponent,
     MselInfoComponent,
+    IntegrationStatusComponent,
     MselListComponent,
     MselPageComponent,
     MselTeamsComponent,

--- a/src/app/components/integration-status/integration-status.component.html
+++ b/src/app/components/integration-status/integration-status.component.html
@@ -1,0 +1,45 @@
+<!--
+Copyright 2026 Carnegie Mellon University. All Rights Reserved.
+Released under a MIT (SEI)-style license, please see LICENSE.md in the
+project root for license information or contact permission@sei.cmu.edu for full terms.
+-->
+<div class="integration-status-container">
+  <div class="status-card">
+    @if (!isError) {
+      <h2 class="status-heading">Processing integrations ...</h2>
+      <mat-progress-bar mode="indeterminate" class="progress-bar"></mat-progress-bar>
+      <p class="status-message">{{ statusMessage }} ...</p>
+      @if (!isPulling) {
+        <div class="action-buttons">
+          @if (!isCancelling) {
+            <button mat-raised-button color="warn" (click)="cancelPush()"
+                    title="Cancel the integration push and remove partial integrations">
+              Cancel Push
+            </button>
+          }
+          @if (isCancelling) {
+            <span class="cancelling-text">Cancelling...</span>
+          }
+        </div>
+      }
+    }
+
+    @if (isError) {
+      <h2 class="status-heading">Integration Failed</h2>
+      <div class="error-message">
+        <mat-icon fontIcon="mdi-alert-circle" class="mdi-24px error-icon"></mat-icon>
+        <span>{{ statusMessage }}</span>
+      </div>
+      <div class="action-buttons">
+        <button mat-raised-button color="warn" (click)="pullIntegrations()"
+                title="Remove partial integrations from associated applications">
+          Pull Integrations
+        </button>
+        <button mat-raised-button (click)="close()"
+                title="Dismiss this message and return to MSEL info">
+          Close
+        </button>
+      </div>
+    }
+  </div>
+</div>

--- a/src/app/components/integration-status/integration-status.component.scss
+++ b/src/app/components/integration-status/integration-status.component.scss
@@ -1,0 +1,62 @@
+// Copyright 2026 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the
+// project root for license information.
+
+.integration-status-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  min-height: 300px;
+  padding: 24px;
+}
+
+.status-card {
+  text-align: center;
+  max-width: 500px;
+  width: 100%;
+}
+
+.status-heading {
+  margin-bottom: 24px;
+  font-weight: 500;
+  color: var(--sys-mat-on-surface);
+}
+
+.progress-bar {
+  margin-bottom: 16px;
+}
+
+.status-message {
+  font-size: 14px;
+  color: var(--sys-mat-on-surface);
+  margin-bottom: 24px;
+}
+
+.error-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--sys-mat-error, #d32f2f);
+  margin-bottom: 24px;
+  padding: 12px;
+  background-color: var(--sys-mat-error-container, #ffebee);
+  border-radius: 4px;
+}
+
+.error-icon {
+  color: var(--sys-mat-error, #d32f2f);
+}
+
+.action-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.cancelling-text {
+  font-style: italic;
+  color: var(--sys-mat-on-surface);
+}

--- a/src/app/components/integration-status/integration-status.component.ts
+++ b/src/app/components/integration-status/integration-status.component.ts
@@ -14,6 +14,7 @@ import { DialogService } from 'src/app/services/dialog/dialog.service';
 export class IntegrationStatusComponent {
   @Input() msel: MselPlus;
   @Output() closed = new EventEmitter<void>();
+  cancelClicked = false;
 
   constructor(
     private mselDataService: MselDataService,
@@ -25,7 +26,7 @@ export class IntegrationStatusComponent {
   }
 
   get isCancelling(): boolean {
-    return this.msel?.integrationStatus?.startsWith('Cancelling') || false;
+    return this.cancelClicked || this.msel?.integrationStatus?.startsWith('Cancelling') || false;
   }
 
   get isPulling(): boolean {
@@ -40,6 +41,7 @@ export class IntegrationStatusComponent {
   }
 
   cancelPush() {
+    this.cancelClicked = true;
     this.mselDataService.cancelIntegrations(this.msel.id);
   }
 

--- a/src/app/components/integration-status/integration-status.component.ts
+++ b/src/app/components/integration-status/integration-status.component.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the
+// project root for license information.
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MselDataService, MselPlus } from 'src/app/data/msel/msel-data.service';
+import { DialogService } from 'src/app/services/dialog/dialog.service';
+
+@Component({
+  selector: 'app-integration-status',
+  templateUrl: './integration-status.component.html',
+  styleUrls: ['./integration-status.component.scss'],
+  standalone: false
+})
+export class IntegrationStatusComponent {
+  @Input() msel: MselPlus;
+  @Output() closed = new EventEmitter<void>();
+
+  constructor(
+    private mselDataService: MselDataService,
+    private dialogService: DialogService
+  ) {}
+
+  get isError(): boolean {
+    return this.msel?.integrationStatus?.startsWith('ERROR') || false;
+  }
+
+  get isCancelling(): boolean {
+    return this.msel?.integrationStatus?.startsWith('Cancelling') || false;
+  }
+
+  get isPulling(): boolean {
+    return this.msel?.integrationStatus?.startsWith('Pulling') || false;
+  }
+
+  get statusMessage(): string {
+    if (this.isError) {
+      return this.msel.integrationStatus.substring(7);
+    }
+    return this.msel?.integrationStatus || '';
+  }
+
+  cancelPush() {
+    this.mselDataService.cancelIntegrations(this.msel.id);
+  }
+
+  pullIntegrations() {
+    this.dialogService
+      .confirm(
+        'Remove Integrations',
+        'Are you sure you want to remove partial integrations from the associated applications?'
+      )
+      .subscribe((result) => {
+        if (result['confirm']) {
+          this.mselDataService.pullIntegrations(this.msel.id);
+          this.closed.emit();
+        }
+      });
+  }
+
+  close() {
+    this.closed.emit();
+  }
+}

--- a/src/app/components/landing/launch/launch.component.ts
+++ b/src/app/components/landing/launch/launch.component.ts
@@ -83,54 +83,49 @@ export class LaunchComponent implements OnDestroy, OnInit {
       .subscribe((msels) => {
         this.launchMselList = msels;
       });
-    // subscribe to MSEL push statuses
-    this.mselDataService.mselPushStatuses
+    // subscribe to MSEL updates to track integration status changes
+    this.mselDataService.MselList
       .pipe(takeUntil(this.unsubscribe$))
-      .subscribe((mselPushStatuses) => {
-        const mselPushStatus = mselPushStatuses.find(
-          (mps) => mps.mselId === this.launchedMsel.id
-        );
-        if (mselPushStatus) {
-          console.log('mselPushStatus is ' + mselPushStatus.pushStatus);
-          if (mselPushStatus.pushStatus) {
-            console.log('set launch status to ' + mselPushStatus.pushStatus);
-            this.launchStatus = mselPushStatus.pushStatus;
+      .subscribe((msels) => {
+        if (!this.launchedMsel?.id) return;
+        const updatedMsel = msels.find(m => m.id === this.launchedMsel.id);
+        if (!updatedMsel) return;
+        this.launchedMsel = updatedMsel;
+        if (updatedMsel.integrationStatus) {
+          this.launchStatus = updatedMsel.integrationStatus;
+        } else if (!updatedMsel.integrationStatus && this.launchStatus) {
+          // Integration push completed
+          if (updatedMsel.playerViewId) {
+            this.launchStatus = 'Adding event management ...';
+            // add a manage event application
+            const playerApplication = {
+              mselId: this.launchedMsel.id,
+              name: 'Manage Event',
+              url:
+                document.baseURI +
+                '/manage?msel=' +
+                this.launchedMsel.id +
+                '&{theme}',
+              icon: document.baseURI + 'assets/img/pencil-ruler-blue.png',
+              embeddable: true,
+              loadInBackground: false,
+            };
+            this.playerApplicationDataService
+              .addAndPush(playerApplication)
+              .pipe(take(1))
+              .subscribe((s) => {
+                // redirect to player view
+                this.launchStatus = 'Completing event processing ...';
+                let playerUrl = this.settingsService.settings.PlayerUrl;
+                if (playerUrl.slice(-1) !== '/') {
+                  playerUrl = playerUrl + '/';
+                }
+                playerUrl =
+                  playerUrl + 'view/' + this.launchedMsel.playerViewId;
+                location.href = playerUrl;
+              });
           } else {
-            if (this.launchedMsel.playerViewId) {
-              console.log('set launch status to Adding event management ...');
-              this.launchStatus = 'Adding event management ...';
-              // add a manage event application
-              const playerApplication = {
-                mselId: this.launchedMsel.id,
-                name: 'Manage Event',
-                url:
-                  document.baseURI +
-                  '/manage?msel=' +
-                  this.launchedMsel.id +
-                  '&{theme}',
-                icon: document.baseURI + 'assets/img/pencil-ruler-blue.png',
-                embeddable: true,
-                loadInBackground: false,
-              };
-              console.log('add new player application');
-              this.playerApplicationDataService
-                .addAndPush(playerApplication)
-                .pipe(take(1))
-                .subscribe((s) => {
-                  // redirect to player view
-                  this.launchStatus = 'Completing event processing ...';
-                  let playerUrl = this.settingsService.settings.PlayerUrl;
-                  if (playerUrl.slice(-1) !== '/') {
-                    playerUrl = playerUrl + '/';
-                  }
-                  playerUrl =
-                    playerUrl + 'view/' + this.launchedMsel.playerViewId;
-                  location.href = playerUrl;
-                });
-            } else {
-              console.log('clearing launch status');
-              this.launchStatus = '';
-            }
+            this.launchStatus = '';
           }
         }
       });

--- a/src/app/components/msel-info/msel-info.component.html
+++ b/src/app/components/msel-info/msel-info.component.html
@@ -3,6 +3,9 @@ Copyright 2022 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license, please see LICENSE.md in the
 project root for license information or contact permission@sei.cmu.edu for full terms.
 -->
+@if (msel?.integrationStatus && !integrationDismissed) {
+  <app-integration-status [msel]="msel" (closed)="dismissIntegrationStatus()"></app-integration-status>
+} @else {
 <div class="frame">
   <mat-tab-group mat-align-tabs="start" class="tab-group" [selectedIndex]="currentTabIndex" (selectedIndexChange)="onTabIndexChange($event)">
     >
@@ -433,3 +436,4 @@ project root for license information or contact permission@sei.cmu.edu for full 
     }
   </mat-tab-group>
 </div>
+}

--- a/src/app/components/msel-info/msel-info.component.ts
+++ b/src/app/components/msel-info/msel-info.component.ts
@@ -126,7 +126,6 @@ export class MselInfoComponent implements OnDestroy, OnInit {
   dataFieldList: DataField[] = [];
   scenarioEventList: ScenarioEvent[] = [];
   basePageUrl = document.baseURI + '/mselpage/';
-  pushStatus = '';
   savedStartTime: Date;
   savedDurationSeconds = 0;
   playerViewName = '';
@@ -135,6 +134,10 @@ export class MselInfoComponent implements OnDestroy, OnInit {
   citeEvaluationName = '';
   citeScoringModelName = '';
   steamfitterScenarioName = '';
+  integrationDismissed = false;
+  get pushStatus(): string {
+    return this.msel?.integrationStatus || '';
+  }
   constructor(
     public dialogService: DialogService,
     private teamQuery: TeamQuery,
@@ -172,6 +175,10 @@ export class MselInfoComponent implements OnDestroy, OnInit {
           this.savedDurationSeconds = msel.durationSeconds;
           // Update scoring model name when scoring model ID changes
           this.updateCiteScoringModelName();
+          // Reset dismissed flag when a new integration push starts
+          if (msel.integrationStatus && !msel.integrationStatus.startsWith('ERROR')) {
+            this.integrationDismissed = false;
+          }
           // Fetch integration names for deployed integrations
           this.fetchIntegrationNames();
         }
@@ -182,25 +189,6 @@ export class MselInfoComponent implements OnDestroy, OnInit {
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((isLoading) => {
         this.isBusy = isLoading;
-      });
-    // subscribe to MSEL push statuses
-    this.mselDataService.mselPushStatuses
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe((mselPushStatuses) => {
-        const mselPushStatus = mselPushStatuses.find(
-          (mps) => mps.mselId === this.msel.id
-        );
-        if (mselPushStatus) {
-          if (mselPushStatus.pushStatus) {
-            this.pushStatus = mselPushStatus.pushStatus;
-          } else {
-            if (this.pushStatus) {
-              this.pushStatus = '';
-              // added this, because signalR is not updating the actual msel data during a push
-              this.mselDataService.loadById(this.msel.id);
-            }
-          }
-        }
       });
     // subscribe to users
     this.userQuery.selectAll()
@@ -400,7 +388,6 @@ export class MselInfoComponent implements OnDestroy, OnInit {
       .subscribe((result) => {
         if (result['confirm']) {
           this.mselDataService.pushIntegrations(this.msel.id);
-          this.pushStatus = 'Pushing Integrations';
         }
       });
   }
@@ -416,6 +403,10 @@ export class MselInfoComponent implements OnDestroy, OnInit {
           this.mselDataService.pullIntegrations(this.msel.id);
         }
       });
+  }
+
+  dismissIntegrationStatus() {
+    this.integrationDismissed = true;
   }
 
   onTabIndexChange(targetIndex: number) {
@@ -668,6 +659,16 @@ export class MselInfoComponent implements OnDestroy, OnInit {
   }
 
   fetchIntegrationNames() {
+    // Only fetch names when integrations are fully deployed
+    if (this.msel.status !== 'Deployed') {
+      this.playerViewName = '';
+      this.galleryCollectionName = '';
+      this.galleryExhibitName = '';
+      this.citeEvaluationName = '';
+      this.citeScoringModelName = '';
+      this.steamfitterScenarioName = '';
+      return;
+    }
     // Fetch Player View name
     if (this.msel.playerViewId) {
       const playerApiUrl = this.settingsService.settings.PlayerApiUrl || '';

--- a/src/app/data/msel/msel-data.service.ts
+++ b/src/app/data/msel/msel-data.service.ts
@@ -28,11 +28,6 @@ import { map, take, tap } from 'rxjs/operators';
 import { BehaviorSubject, Observable, Subject, combineLatest } from 'rxjs';
 import { ErrorService } from 'src/app/services/error/error.service';
 
-export interface MselPushStatus {
-  mselId: string;
-  pushStatus: string;
-}
-
 @Injectable({
   providedIn: 'root',
 })
@@ -45,6 +40,7 @@ export class MselPlus implements Msel {
   name?: string;
   description?: string;
   status?: MselItemStatus;
+  integrationStatus?: string;
   usePlayer?: boolean;
   playerViewId?: string;
   useGallery?: boolean;
@@ -191,8 +187,6 @@ export class MselDataService {
   readonly pageEvent = new BehaviorSubject<PageEvent>(this._pageEvent);
   private pageSize: Observable<number>;
   private pageIndex: Observable<number>;
-  public mselPushStatuses = new Subject<Array<MselPushStatus>>();
-  private _mselPushStatuses = new Array<MselPushStatus>();
   public uploadProgress = new Subject<number>();
 
   constructor(
@@ -456,20 +450,16 @@ export class MselDataService {
       );
   }
 
-  mselPushStatusChange(mselPushStatus: string) {
-    let notFound = true;
-    const parts = mselPushStatus.split(',');
-    const newPushStatus = { mselId: parts[0], pushStatus: parts[1] };
-    this._mselPushStatuses.forEach((mps) => {
-      if (mps.mselId === newPushStatus.mselId) {
-        mps.pushStatus = newPushStatus.pushStatus;
-        notFound = false;
-      }
-    });
-    if (notFound) {
-      this._mselPushStatuses.push(newPushStatus);
-    }
-    this.mselPushStatuses.next(this._mselPushStatuses);
+  cancelIntegrations(mselId: string) {
+    this.mselService
+      .cancelIntegrations(mselId)
+      .pipe(take(1))
+      .subscribe(
+        () => {},
+        (error) => {
+          this.errorService.handleError(error);
+        }
+      );
   }
 
   archive(mselId: string) {

--- a/src/app/data/msel/msel-data.service.ts
+++ b/src/app/data/msel/msel-data.service.ts
@@ -644,6 +644,10 @@ export class MselDataService {
     this.mselStore.upsert(msel.id, msel);
   }
 
+  updateIntegrationStatus(mselId: string, integrationStatus: string) {
+    this.mselStore.update(mselId, { integrationStatus });
+  }
+
   deleteFromStore(id: string) {
     this.mselStore.remove(id);
   }

--- a/src/app/generated/blueprint.api/api/msel.service.ts
+++ b/src/app/generated/blueprint.api/api/msel.service.ts
@@ -1067,9 +1067,48 @@ export class MselService extends BaseService {
     }
 
     /**
+     * Cancel pushing integrations and remove any partial integrations
+     * Cancels an in-progress integration push and removes any partially created integrations &lt;para /&gt; Accessible only to a ContentDeveloper or MSEL owner
+     * @param id The id of the MSEL
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public cancelIntegrations(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined, context?: HttpContext, transferCache?: boolean}): Observable<any>;
+    public cancelIntegrations(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined, context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<any>>;
+    public cancelIntegrations(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined, context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<any>>;
+    public cancelIntegrations(id: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: undefined, context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (id === null || id === undefined) {
+            throw new Error('Required parameter id was null or undefined when calling cancelIntegrations.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        // authentication (oauth2) required
+        localVarHeaders = this.configuration.addCredentialToHeaders('oauth2', 'Authorization', localVarHeaders, 'Bearer ');
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+        let localVarPath = `/api/msels/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: "uuid"})}/integrations/cancel`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<any>('post', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                responseType: 'text' as 'json',
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                transferCache: localVarTransferCache,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
      * Push Integrations
      * Pushes all MSEL Integrations to the associated applications &lt;para /&gt; Accessible only to a ContentDeveloper or MSEL owner
-     * @param id 
+     * @param id
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */

--- a/src/app/generated/blueprint.api/model/msel.ts
+++ b/src/app/generated/blueprint.api/model/msel.ts
@@ -39,6 +39,7 @@ export interface Msel {
     name?: string | null;
     description?: string | null;
     status?: MselItemStatus;
+    integrationStatus?: string | null;
     usePlayer?: boolean;
     playerViewId?: string | null;
     playerIntegrationType?: IntegrationType;

--- a/src/app/generated/blueprint.api/model/mselItemStatus.ts
+++ b/src/app/generated/blueprint.api/model/mselItemStatus.ts
@@ -20,6 +20,8 @@ export const MselItemStatus = {
     Entered: 'Entered',
     Approved: 'Approved',
     Complete: 'Complete',
+    Pushing: 'Pushing',
+    Pulling: 'Pulling',
     Deployed: 'Deployed',
     Archived: 'Archived'
 } as const;

--- a/src/app/services/integration-in-progress.guard.ts
+++ b/src/app/services/integration-in-progress.guard.ts
@@ -1,0 +1,25 @@
+// Copyright 2026 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the
+// project root for license information.
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+import { MselQuery } from 'src/app/data/msel/msel.query';
+import { MselPlus } from 'src/app/data/msel/msel-data.service';
+
+@Injectable({ providedIn: 'root' })
+export class IntegrationInProgressGuard implements CanDeactivate<any> {
+  constructor(private mselQuery: MselQuery) {}
+
+  canDeactivate(): boolean {
+    const msel = this.mselQuery.getActive() as MselPlus;
+    if (
+      msel?.integrationStatus &&
+      !msel.integrationStatus.startsWith('ERROR')
+    ) {
+      return confirm(
+        'An integration push is in progress. Are you sure you want to leave?'
+      );
+    }
+    return true;
+  }
+}

--- a/src/app/services/signalr.service.ts
+++ b/src/app/services/signalr.service.ts
@@ -373,9 +373,6 @@ export class SignalRService implements OnDestroy {
       this.mselDataService.deleteFromStore(id);
     });
 
-    this.hubConnection.on('MselPushStatusChange', (mselPushStatus: string) => {
-      this.mselDataService.mselPushStatusChange(mselPushStatus);
-    });
   }
 
   private addMselUnitHandlers() {

--- a/src/app/services/signalr.service.ts
+++ b/src/app/services/signalr.service.ts
@@ -373,6 +373,10 @@ export class SignalRService implements OnDestroy {
       this.mselDataService.deleteFromStore(id);
     });
 
+    this.hubConnection.on('IntegrationStatusUpdated', (mselId: string, integrationStatus: string) => {
+      this.mselDataService.updateIntegrationStatus(mselId, integrationStatus);
+    });
+
   }
 
   private addMselUnitHandlers() {


### PR DESCRIPTION
  - Add IntegrationStatus component that displays live progress during push/pull, with Cancel Push button (hidden during pull), and an error state showing the failure message with Pull Integrations and Close buttons
  - Show IntegrationStatus overlay in MselInfo instead of MSEL tabs while integrationStatus is set; dismiss returns to tabs without reverting on error
  - Drive push status from msel.integrationStatus (SignalR-updated) instead of a separate mselPushStatuses observable
  - Skip fetching integration names (Player view, Gallery, CITE, Steamfitter) when MSEL status is not Deployed to avoid 404s during push/pull
  - Add IntegrationInProgressGuard to warn before navigating away during an active push or pull
  - Add Pushing and Pulling to the MselItemStatus enum
  - Add cancelIntegrations and pullIntegrations API calls; fix cancelIntegrations to use responseType 'text' to handle empty 200 response body
  - Sync generated blueprint.api model with new IntegrationStatus and Pushing/Pulling status values