### PR TITLE
Fix inject list reactivity and admin inject type copy + add user presence bar

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -121,6 +121,7 @@ import { TeamAddDialogComponent } from './components/team-add-dialog/team-add-di
 import { TeamEditDialogComponent } from './components/team-edit-dialog/team-edit-dialog.component';
 import { TeamUsersComponent } from './components/team-users/team-users.component';
 import { TopbarComponent } from './components/shared/top-bar/topbar.component';
+import { PresenceBarComponent } from './components/shared/presence-bar/presence-bar.component';
 import { UIDataService } from './data/ui/ui-data.service';
 import { UserDataService } from './data/user/user-data.service';
 import { DialogService } from './services/dialog/dialog.service';
@@ -227,6 +228,7 @@ export const appConfig: ApplicationConfig = {
     AdminGroupsMembershipListComponent,
     NameDialogComponent,
     TopbarComponent,
+    PresenceBarComponent,
     DisplayOrderPipe,
     SortByPipe,
     PlainTextPipe,

--- a/src/app/components/admin/admin-catalog-list/admin-catalog-list.component.scss
+++ b/src/app/components/admin/admin-catalog-list/admin-catalog-list.component.scss
@@ -63,6 +63,8 @@
 
 .detail-row {
   height: 0;
+  min-height: 0;
+  --mat-table-row-item-outline-width: 0px;
 }
 
 .element-row td {

--- a/src/app/components/admin/admin-inject-types/admin-inject-types.component.scss
+++ b/src/app/components/admin/admin-inject-types/admin-inject-types.component.scss
@@ -16,6 +16,7 @@
 .expansion-panel {
   width: 90%;
   background-color: transparent;
+  margin-top: 8px;
   margin-bottom: 10px;
 }
 
@@ -74,6 +75,9 @@
 
 .detail-row {
   height: 0;
+  min-height: 0;
+  overflow: hidden;
+  --mat-table-row-item-outline-width: 0px;
 }
 
 .element-row td {
@@ -113,8 +117,6 @@
   flex-direction: column;
   width: 100%;
   min-width: 660px;
-  padding: 8px 10px;
-  gap: 8px;
 }
 
 .row:has(.expanded-detail-div) {

--- a/src/app/components/admin/admin-inject-types/admin-inject-types.component.ts
+++ b/src/app/components/admin/admin-inject-types/admin-inject-types.component.ts
@@ -139,7 +139,16 @@ export class AdminInjectTypesComponent implements OnDestroy, AfterViewInit {
   }
 
   copyInjectType(injectType: InjectType): void {
-    // this.injectTypeDataService.copy(id);
+    const newId = uuidv4();
+    const copy: InjectType = {
+      ...injectType,
+      id: newId,
+      name: 'Copy of ' + injectType.name,
+      dataFields: injectType.dataFields
+        ? injectType.dataFields.map(df => ({ ...df, id: uuidv4(), injectTypeId: newId }))
+        : [],
+    };
+    this.injectTypeDataService.add(copy);
   }
 
   sortChanged(sort: Sort) {

--- a/src/app/components/home-app/home-app.component.ts
+++ b/src/app/components/home-app/home-app.component.ts
@@ -100,6 +100,7 @@ export class HomeAppComponent implements OnDestroy, OnInit {
         if (!this.selectedMselId) {
           // set appTitle and topbarText for top level
           this.mselDataService.setActive('');
+          this.signalRService.clearPresence();
           this.topbarText = this.topbarTextBase;
           this.titleService.setTitle(this.appTitle);
         }

--- a/src/app/components/inject-list/inject-list.component.ts
+++ b/src/app/components/inject-list/inject-list.component.ts
@@ -113,6 +113,7 @@ export class InjectListComponent implements OnDestroy, OnInit {
       .selectAll()
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((injects) => {
+        this.injectList = [];
         // get editable objects
         injects.forEach((m) => {
           const inject = { ...m };
@@ -120,14 +121,7 @@ export class InjectListComponent implements OnDestroy, OnInit {
           m.dataValues.forEach((dv) => {
             inject.dataValues.push({ ...dv });
           });
-          const index = this.injectList
-            ? this.injectList.findIndex((i) => i.id === inject.id)
-            : -1;
-          if (index === -1) {
-            this.injectList.push(inject);
-          } else {
-            this.injectList[index] = inject;
-          }
+          this.injectList.push(inject);
         });
         this.sortChanged(this.sort);
       });
@@ -243,10 +237,14 @@ export class InjectListComponent implements OnDestroy, OnInit {
       newDataValue.injectId = newInjectId;
       newInject.dataValues.push(newDataValue);
     });
-    this.editInject(newInject, true);
+    // When in the inject type view (no catalog context), resolve the catalogId from
+    // the first catalog that belongs to this inject type.
+    const catalogId = this.catalog.id ||
+      this.catalogList.find(c => c.injectTypeId === this.injectType.id)?.id;
+    this.editInject(newInject, true, catalogId);
   }
 
-  editInject(inject: Injectm, isNewInject?: boolean) {
+  editInject(inject: Injectm, isNewInject?: boolean, catalogId?: string) {
     const dialogRef = this.dialog.open(InjectEditDialogComponent, {
       minWidth: '400px',
       maxWidth: '90vw',
@@ -265,7 +263,7 @@ export class InjectListComponent implements OnDestroy, OnInit {
       if (result.saveChanges && result.inject) {
         // save the inject (add or update)
         if (isNewInject) {
-          this.injectmDataService.add(this.catalog.id, result.inject);
+          this.injectmDataService.add((this.catalog.id || catalogId) as string, result.inject);
         } else {
           this.injectmDataService.update(result.inject);
         }

--- a/src/app/components/shared/presence-bar/presence-bar.component.html
+++ b/src/app/components/shared/presence-bar/presence-bar.component.html
@@ -1,0 +1,15 @@
+<!--
+Copyright 2024 Carnegie Mellon University. All Rights Reserved.
+Released under a MIT (SEI)-style license, please see LICENSE.md in the
+project root for license information or contact permission@sei.cmu.edu for full terms.
+-->
+@if (actors.length > 0) {
+<div class="presence-container">
+  @for (actor of actors; track actor.id) {
+  <span class="presence-chip" [class.presence-offline]="!actor.online">
+    <mat-icon class="presence-icon" fontIcon="mdi-account"></mat-icon>
+    <span class="presence-name">{{ actor.name || 'Anonymous' }}</span>
+  </span>
+  }
+</div>
+}

--- a/src/app/components/shared/presence-bar/presence-bar.component.scss
+++ b/src/app/components/shared/presence-bar/presence-bar.component.scss
@@ -1,0 +1,41 @@
+// Copyright 2024 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the
+// project root for license information.
+
+.presence-container {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 12px;
+}
+
+.presence-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border-radius: 16px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 20px;
+  white-space: nowrap;
+  background-color: #a5d6a7;
+  color: #1b5e20;
+}
+
+.presence-icon {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+}
+
+.presence-name {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+// Offline modifier
+.presence-offline {
+  opacity: 0.4;
+}

--- a/src/app/components/shared/presence-bar/presence-bar.component.ts
+++ b/src/app/components/shared/presence-bar/presence-bar.component.ts
@@ -1,0 +1,38 @@
+// Copyright 2024 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the
+// project root for license information.
+
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { PresenceActor, SignalRService } from 'src/app/services/signalr.service';
+
+@Component({
+  selector: 'app-presence-bar',
+  templateUrl: './presence-bar.component.html',
+  styleUrls: ['./presence-bar.component.scss'],
+  standalone: false,
+})
+export class PresenceBarComponent implements OnInit, OnDestroy {
+  actors: PresenceActor[] = [];
+  private unsubscribe$ = new Subject<null>();
+
+  constructor(
+    private signalRService: SignalRService,
+    private changeDetectorRef: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.signalRService.actors$
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((actors) => {
+        this.actors = actors;
+        this.changeDetectorRef.detectChanges();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next(null);
+    this.unsubscribe$.complete();
+  }
+}

--- a/src/app/components/shared/top-bar/topbar.component.html
+++ b/src/app/components/shared/top-bar/topbar.component.html
@@ -30,6 +30,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
     </div>
     }
     }
+    <app-presence-bar></app-presence-bar>
     <span class="spacer"></span>
     @if (currentUser$ | async; as currentUser) {
     <div class="options-text">

--- a/src/app/services/signalr.service.ts
+++ b/src/app/services/signalr.service.ts
@@ -51,8 +51,15 @@ import { TeamDataService } from 'src/app/data/team/team-data.service';
 import { TeamUserDataService } from '../data/team-user/team-user-data.service';
 import { UserDataService } from 'src/app/data/user/user-data.service';
 import { UserMselRoleDataService } from '../data/user-msel-role/user-msel-role-data.service';
-import { Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+
+export interface PresenceActor {
+  id: string;
+  name: string;
+  online: boolean;
+  color: string;
+}
 
 export enum ApplicationArea {
   home = '',
@@ -69,6 +76,9 @@ export class SignalRService implements OnDestroy {
   private mselId = '';
   private token = '';
   private unsubscribe$ = new Subject();
+  private presenceActors: PresenceActor[] = [];
+  private presenceColorMap = ['primary', 'accent', 'green', 'orange', 'purple'];
+  actors$ = new BehaviorSubject<PresenceActor[]>([]);
 
   constructor(
     private authService: ComnAuthService,
@@ -151,6 +161,9 @@ export class SignalRService implements OnDestroy {
       this.hubConnection.invoke('Leave' + this.applicationArea);
     }
     this.isJoined = false;
+    this.mselId = '';
+    this.presenceActors = [];
+    this.actors$.next([]);
   }
 
   public selectMsel(mselId: string) {
@@ -158,10 +171,31 @@ export class SignalRService implements OnDestroy {
       setTimeout(() => this.selectMsel(mselId), 500);
     } else if (this.isJoined) {
       if (this.applicationArea !== ApplicationArea.admin) {
+        this.presenceActors = [];
+        this.actors$.next([]);
         this.hubConnection.invoke('selectMsel', [mselId]);
         this.mselId = mselId;
+        // fetch current presence so we don't rely solely on greet-back
+        this.hubConnection.invoke('GetPresence', mselId).then(
+          (actors: { id: string; name: string }[]) => {
+            if (actors) {
+              for (const actor of actors) {
+                this.updatePresence(actor, true);
+              }
+            }
+          }
+        );
       }
     }
+  }
+
+  public clearPresence() {
+    if (this.hubConnection?.state === signalR.HubConnectionState.Connected && this.mselId) {
+      this.hubConnection.invoke('selectMsel', []);
+    }
+    this.mselId = '';
+    this.presenceActors = [];
+    this.actors$.next([]);
   }
 
   private reconnect() {
@@ -204,6 +238,7 @@ export class SignalRService implements OnDestroy {
     this.addTeamUserHandlers();
     this.addUserHandlers();
     this.addUserMselRoleHandlers();
+    this.addPresenceHandlers();
   }
 
   private addCardHandlers() {
@@ -529,6 +564,41 @@ export class SignalRService implements OnDestroy {
     this.hubConnection.on('UserMselRoleDeleted', (id: string) => {
       this.userMselRoleDataService.deleteFromStore(id);
     });
+  }
+
+  private addPresenceHandlers() {
+    this.hubConnection.on('PresenceArrived', (actor: { id: string; name: string }) => {
+      this.updatePresence(actor, true);
+      // greet back so the newcomer sees us
+      if (this.mselId) {
+        this.hubConnection.invoke('Greet', this.mselId);
+      }
+    });
+
+    this.hubConnection.on('PresenceGreeted', (actor: { id: string; name: string }) => {
+      this.updatePresence(actor, true);
+    });
+
+    this.hubConnection.on('PresenceDeparted', (actor: { id: string; name: string }) => {
+      this.presenceActors = this.presenceActors.filter(a => a.id !== actor.id);
+      this.actors$.next([...this.presenceActors]);
+    });
+  }
+
+  private updatePresence(actor: { id: string; name: string }, online: boolean) {
+    const existing = this.presenceActors.find(a => a.id === actor.id);
+    if (existing) {
+      existing.online = online;
+      existing.name = actor.name;
+    } else {
+      this.presenceActors.push({
+        id: actor.id,
+        name: actor.name,
+        online,
+        color: this.presenceColorMap[this.presenceActors.length % this.presenceColorMap.length],
+      });
+    }
+    this.actors$.next([...this.presenceActors]);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
 Summary                                                                                                         

  - Bug fix: Inject list now rebuilds correctly on subscription updates instead of doing in-place upserts that could
   leave stale entries after a catalog copy.
  - Bug fix: Adding an inject from the inject type admin view (no catalog context) now correctly resolves the
  catalogId so the inject is saved.                                                                                 
  - Feature: Implements a real-time user presence bar in the top bar showing who else is currently viewing the same
  MSEL.                                                                                                             
  - Feature: copyInjectType in admin is now implemented — previously a no-op stub.
  - Polish: CSS fixes for detail row height/overflow in catalog list and inject types tables.

  Changes

  signalr.service.ts — adds presence tracking:
  - New PresenceActor interface (id, name, online, color)
  - actors$ (BehaviorSubject) exposes the current presence list to components
  - selectMsel: clears presence state on MSEL switch, then calls GetPresence to fetch users already in the MSEL
  - clearPresence(): invokes selectMsel([]) on the hub and resets local state — called when navigating away from a
  MSEL
  - addPresenceHandlers(): registers hub event handlers for PresenceArrived (updates presence + greets back),
  PresenceGreeted (updates presence), and PresenceDeparted (removes actor)

  presence-bar.component.* (new) — shared component that renders a chip for each active presence actor. Shows a
  person icon + display name, with an offline opacity modifier. Chips are rendered only when at least one actor is
  present.

  topbar.component.html — embeds <app-presence-bar> in the top bar between the breadcrumb area and the spacer.

  home-app.component.ts — calls signalRService.clearPresence() when navigating back to the top level (no MSEL
  selected).

  inject-list.component.ts:
  - Fixes reactivity: resets injectList = [] at the start of each subscription emit instead of doing
  find-and-replace upserts, ensuring deleted injects are removed from the view
  - Fixes copyInject: resolves catalogId from the catalog list when this.catalog.id is empty (inject type admin
  context)
  - Threads the resolved catalogId through to injectmDataService.add()

  admin-inject-types.component.ts — implements copyInjectType: creates a deep copy with new UUIDs for the inject
  type and all its data fields, then calls injectTypeDataService.add().

  CSS fixes — detail-row in both catalog list and inject types tables now sets min-height: 0 and
  --mat-table-row-item-outline-width: 0px to prevent collapsed rows from taking up visible space in newer Angular
  Material versions.