### PR TITLE
Fix race condition on direct MSEL URL navigation

### DIFF
--- a/src/app/components/home-app/home-app.component.ts
+++ b/src/app/components/home-app/home-app.component.ts
@@ -66,6 +66,7 @@ export class HomeAppComponent implements OnDestroy, OnInit {
   appTitle = '';
   permissions: SystemPermission[] = [];
   readonly SystemPermission = SystemPermission;
+  private mselWasActive = false;
 
   constructor(
     activatedRoute: ActivatedRoute,
@@ -110,11 +111,12 @@ export class HomeAppComponent implements OnDestroy, OnInit {
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((m) => {
         if (m) {
+          this.mselWasActive = true;
           // set appTitle and topbarText for the selected MSEL
           const prefix = this.appTitle + ' - ';
           this.topbarText = m ? prefix + m.name : this.topbarTextBase;
           this.titleService.setTitle(prefix + m.name);
-        } else if (this.selectedMselId) {
+        } else if (this.selectedMselId && this.mselWasActive) {
           // active MSEL was deleted, navigate back to the list
           this.selectedMselId = '';
           this.topbarText = this.topbarTextBase;


### PR DESCRIPTION
When navigating directly to /build?msel=<id>, selectActive() emits null before the MSEL loads from the API. The delete-redirect handler interpreted this as a deleted MSEL and navigated to /build, dropping the query parameter.

Add mselWasActive flag so the redirect only fires after the MSEL has actually been loaded into the store at least once.

Introduced in 483c9c0 (Fix deleted MSEL still visible in list #247).