### PR TITLE
Restyle contributors, teams, and invitations pages

### DIFF
--- a/src/app/components/admin/admin-catalog-list/admin-catalog-list.component.html
+++ b/src/app/components/admin/admin-catalog-list/admin-catalog-list.component.html
@@ -23,7 +23,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
 </div>
 
 <section class="scrolling-region">
-  <table mat-table #catalogTable [dataSource]="catalogDataSource" matSort multiTemplateDataRows>
+  <table mat-table #catalogTable [dataSource]="catalogDataSource" matSort (matSortChange)="sortChanged($event)" multiTemplateDataRows>
     <!-- action column -->
     <ng-container matColumnDef="action">
       <mat-header-cell *matHeaderCellDef class="column-action">
@@ -75,7 +75,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
     </ng-container>
     <!-- name Column -->
     <ng-container matColumnDef="name">
-      <mat-header-cell title="Catalog Name" *matHeaderCellDef class="column-name">
+      <mat-header-cell title="Catalog Name" *matHeaderCellDef mat-sort-header class="column-name">
         Name
       </mat-header-cell>
       <mat-cell *matCellDef="let element" class="column-name">
@@ -93,7 +93,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
     </ng-container>
     <!-- description Column -->
     <ng-container matColumnDef="description">
-      <mat-header-cell title="Catalog Description" *matHeaderCellDef class="column-description">
+      <mat-header-cell title="Catalog Description" *matHeaderCellDef mat-sort-header class="column-description">
         Description
       </mat-header-cell>
       <mat-cell *matCellDef="let element" class="column-description">

--- a/src/app/components/admin/admin-catalog-list/admin-catalog-list.component.ts
+++ b/src/app/components/admin/admin-catalog-list/admin-catalog-list.component.ts
@@ -22,7 +22,6 @@ import { Subject, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Catalog, InjectType, Team } from 'src/app/generated/blueprint.api';
 import { Sort } from '@angular/material/sort';
-import { MatMenuTrigger } from '@angular/material/menu';
 import { MatTable } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { CatalogDataService } from 'src/app/data/catalog/catalog-data.service';
@@ -227,13 +226,13 @@ export class AdminCatalogListComponent implements OnDestroy, AfterViewInit {
     switch (column) {
       case 'name':
         return (
-          (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1) *
+          ((a.name ?? '').toLowerCase() < (b.name ?? '').toLowerCase() ? -1 : 1) *
           (isAsc ? 1 : -1)
         );
         break;
       case 'description':
         return (
-          (a.description.toLowerCase() < b.description.toLowerCase() ? -1 : 1) *
+          ((a.description ?? '').toLowerCase() < (b.description ?? '').toLowerCase() ? -1 : 1) *
           (isAsc ? 1 : -1)
         );
         break;

--- a/src/app/components/admin/admin-inject-types/admin-inject-types.component.html
+++ b/src/app/components/admin/admin-inject-types/admin-inject-types.component.html
@@ -23,7 +23,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
 </div>
 
 <section class="scrolling-region">
-  <table mat-table #injectTypeTable [dataSource]="injectTypeDataSource" matSort multiTemplateDataRows>
+  <table mat-table #injectTypeTable [dataSource]="injectTypeDataSource" matSort (matSortChange)="sortChanged($event)" multiTemplateDataRows>
     <!-- action column -->
     <ng-container matColumnDef="action">
       <mat-header-cell *matHeaderCellDef class="column-action">
@@ -57,7 +57,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
     </ng-container>
     <!-- name Column -->
     <ng-container matColumnDef="name">
-      <mat-header-cell title="Inject Type Name" *matHeaderCellDef class="column-name">
+      <mat-header-cell title="Inject Type Name" *matHeaderCellDef mat-sort-header class="column-name">
         Name
       </mat-header-cell>
       <mat-cell *matCellDef="let element" class="column-name">
@@ -66,7 +66,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
     </ng-container>
     <!-- description Column -->
     <ng-container matColumnDef="description">
-      <mat-header-cell title="Inject Type Description" *matHeaderCellDef class="column-description">
+      <mat-header-cell title="Inject Type Description" *matHeaderCellDef mat-sort-header class="column-description">
         Description
       </mat-header-cell>
       <mat-cell *matCellDef="let element" class="column-description">

--- a/src/app/components/admin/admin-inject-types/admin-inject-types.component.ts
+++ b/src/app/components/admin/admin-inject-types/admin-inject-types.component.ts
@@ -15,7 +15,6 @@ import {
 import { MselDataService, MselPlus } from 'src/app/data/msel/msel-data.service';
 import { MselQuery } from 'src/app/data/msel/msel.query';
 import { Sort } from '@angular/material/sort';
-import { MatMenuTrigger } from '@angular/material/menu';
 import { MatTable } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { InjectTypeDataService } from 'src/app/data/inject-type/inject-type-data.service';
@@ -188,10 +187,10 @@ export class AdminInjectTypesComponent implements OnDestroy, AfterViewInit {
     const isAsc = direction !== 'desc';
     switch (column) {
       case 'name':
-        return ((a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
+        return (((a.name ?? '').toLowerCase() < (b.name ?? '').toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
         break;
       case 'description':
-        return ((a.description.toLowerCase() < b.description.toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
+        return (((a.description ?? '').toLowerCase() < (b.description ?? '').toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
         break;
       default:
         return 0;

--- a/src/app/components/invitation-list/invitation-list.component.html
+++ b/src/app/components/invitation-list/invitation-list.component.html
@@ -3,93 +3,102 @@ Copyright 2022 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license, please see LICENSE.md in the
 project root for license information or contact permission@sei.cmu.edu for full terms.
 -->
+
+<div class="cssLayoutRowStartCenter">
+  <div class="sp-icon">
+    <mat-icon class="mdi-24px" fontIcon="mdi-email-open" [ngStyle]="{'color': 'var(--mat-sys-primary)'}"></mat-icon>
+  </div>
+  <mat-form-field style="width: 300px; margin-left: 10px;">
+    <input matInput [(ngModel)]="filterString" (keyup)="applyFilter($any($event.target).value)" placeholder="Search" />
+    @if (filterString) {
+    <button mat-icon-button matSuffix (click)="applyFilter('')" title="Clear Search">
+      <mat-icon style="transform: scale(0.85)" fontIcon="mdi-close-circle-outline"></mat-icon>
+    </button>
+    }
+  </mat-form-field>
+  <div class="button-end">
+    <mat-paginator #paginator [pageIndex]="0" [pageSize]="20"
+      [pageSizeOptions]="[5, 10, 15, 20, 25, 50]"></mat-paginator>
+  </div>
+</div>
+
 @if (msel) {
 <div class="frame">
-  <section class="header-row elevate">
-    <span class="header-cell action-cell">
-      @if (canEditMsel || msel.hasRole(loggedInUserId, null).owner) {
-      <span>
-        <button mat-icon-button (click)="addOrEditInvitation(null, false)" style="outline: none; margin-left: 15px;"
-          title="Add an invitation">
-          <mat-icon class="mdi-24px self-center" fontIcon="mdi-plus-circle"></mat-icon>
-        </button>
-      </span>
-      } &nbsp;
-    </span>
-    <span class="header-cell two-cell">Team</span>
-    <span class="header-cell three-cell">Email Domain</span>
-    <span class="header-cell two-cell">Expires</span>
-    <span class="header-cell one-cell">Max Uses</span>
-    <span class="header-cell one-cell">Remaining Uses</span>
-  </section>
-  <section class="scrolling-region">
-    <div class="table">
-      <mat-table #table [dataSource]="invitationDataSource" matSort>
-        <!-- action column -->
-        <ng-container matColumnDef="action">
-          <mat-cell *matCellDef="let element" class="cell action-cell">
-            <div class="action-div">
-              @if (canEditMsel || msel.hasRole(loggedInUserId, null).owner) {
-              <button mat-icon-button class="msel-action"
-                (click)="addOrEditInvitation(element, true); $event.stopPropagation();"
-                title="Edit {{ element.emailDomain }} invitation">
-                <mat-icon class="mdi-18px" fontIcon="mdi-square-edit-outline"
-                  title="Edit {{ element.emailDomain }} invitation"></mat-icon>
-              </button>
-              }
-              <button mat-icon-button ngxClipboard [cbContent]="getInvitationLink(element.teamId)"
-                title="Copy Invitation Link:  {{ getInvitationLink(element.teamId) }}"
-                [disabled]="getInvitationLink(element.teamId).length === 0">
-                <mat-icon class="mdi-18px" fontIcon="mdi-content-copy"></mat-icon>
-              </button>
-              @if (canEditMsel || msel.hasRole(loggedInUserId, null).owner) {
-              <button mat-icon-button class="msel-action" (click)="deleteInvitation(element); $event.stopPropagation();"
-                title="Delete {{ element.emailDomain }} invitation">
-                <mat-icon class="mdi-18px" fontIcon="mdi-trash-can-outline"
-                  title="Delete {{ element.emailDomain }} invitation"></mat-icon>
-              </button>
-              }
-            </div>
-          </mat-cell>
-        </ng-container>
-        <!-- teamId Column -->
-        <ng-container matColumnDef="teamId">
-          <mat-cell *matCellDef="let element" class="cell two-cell">
-            {{ getTeamName(element.teamId) }}
-          </mat-cell>
-        </ng-container>
-        <!-- emailDomain Column -->
-        <ng-container matColumnDef="emailDomain">
-          <mat-cell *matCellDef="let element" class="cell three-cell">
-            {{ element.emailDomain }}
-          </mat-cell>
-        </ng-container>
-        <!-- expirationDateTime Column -->
-        <ng-container matColumnDef="expirationDateTime">
-          <mat-cell *matCellDef="let element" class="cell two-cell">
-            {{ element.expirationDateTime | date: 'dd MMM yyyy HH:mm' }}
-          </mat-cell>
-        </ng-container>
-        <!-- maxUsersAllowed Column -->
-        <ng-container matColumnDef="usesAllowed">
-          <mat-cell *matCellDef="let element" class="cell one-cell">
-            <div class="number-cell">{{ element.maxUsersAllowed }}</div>
-          </mat-cell>
-        </ng-container>
-        <!-- userCount Column -->
-        <ng-container matColumnDef="usesRemaining">
-          <mat-cell *matCellDef="let element" class="cell one-cell">
-            <div class="number-cell">{{ element.maxUsersAllowed - element.userCount }}</div>
-          </mat-cell>
-        </ng-container>
-        <!-- row definitions -->
-        <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
-      </mat-table>
-      <!-- No Results Message -->
-      @if (invitationDataSource?.filteredData.length === 0) {
-      <div class="text no-results">No invitations found</div>
-      }
-    </div>
-  </section>
+  <div class="table-container">
+    <table mat-table [dataSource]="invitationDataSource" matSort (matSortChange)="sortChanged($event)">
+      <!-- action column -->
+      <ng-container matColumnDef="action">
+        <th mat-header-cell *matHeaderCellDef class="column-action">
+          @if (canEditMsel || msel.hasRole(loggedInUserId, null).owner) {
+          <button mat-icon-button (click)="addOrEditInvitation(null, false)" style="outline: none;"
+            title="Add an invitation">
+            <mat-icon class="mdi-24px center-self" fontIcon="mdi-plus-circle"></mat-icon>
+          </button>
+          }
+        </th>
+        <td mat-cell *matCellDef="let element" class="column-action">
+          @if (canEditMsel || msel.hasRole(loggedInUserId, null).owner) {
+          <button mat-icon-button
+            (click)="addOrEditInvitation(element, true); $event.stopPropagation();"
+            title="Edit {{ element.emailDomain }} invitation">
+            <mat-icon class="mdi-18px" fontIcon="mdi-square-edit-outline"></mat-icon>
+          </button>
+          }
+          <button mat-icon-button ngxClipboard [cbContent]="getInvitationLink(element.teamId)"
+            title="Copy Invitation Link: {{ getInvitationLink(element.teamId) }}"
+            [disabled]="getInvitationLink(element.teamId).length === 0">
+            <mat-icon class="mdi-18px" fontIcon="mdi-content-copy"></mat-icon>
+          </button>
+          @if (canEditMsel || msel.hasRole(loggedInUserId, null).owner) {
+          <button mat-icon-button (click)="deleteInvitation(element); $event.stopPropagation();"
+            title="Delete {{ element.emailDomain }} invitation">
+            <mat-icon class="mdi-18px" fontIcon="mdi-trash-can-outline"></mat-icon>
+          </button>
+          }
+        </td>
+      </ng-container>
+      <!-- team column -->
+      <ng-container matColumnDef="teamId">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-team">Team Short Name</th>
+        <td mat-cell *matCellDef="let element" class="column-team">
+          {{ getTeamName(element.teamId) }}
+        </td>
+      </ng-container>
+      <!-- emailDomain column -->
+      <ng-container matColumnDef="emailDomain">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-email-domain">Email Domain</th>
+        <td mat-cell *matCellDef="let element" class="column-email-domain">
+          {{ element.emailDomain }}
+        </td>
+      </ng-container>
+      <!-- expirationDateTime column -->
+      <ng-container matColumnDef="expirationDateTime">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-expires">Expiration</th>
+        <td mat-cell *matCellDef="let element" class="column-expires">
+          {{ element.expirationDateTime | date: 'dd MMM yyyy HH:mm' }}
+        </td>
+      </ng-container>
+      <!-- maxUsersAllowed column -->
+      <ng-container matColumnDef="usesAllowed">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-uses">Max Uses</th>
+        <td mat-cell *matCellDef="let element" class="column-uses">
+          {{ element.maxUsersAllowed }}
+        </td>
+      </ng-container>
+      <!-- usesRemaining column -->
+      <ng-container matColumnDef="usesRemaining">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-uses">Remaining Uses</th>
+        <td mat-cell *matCellDef="let element" class="column-uses">
+          {{ element.maxUsersAllowed - element.userCount }}
+        </td>
+      </ng-container>
+      <!-- row definitions -->
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+    @if (invitationDataSource?.filteredData.length === 0) {
+    <div class="no-results">No invitations found</div>
+    }
+  </div>
 </div>
 }

--- a/src/app/components/invitation-list/invitation-list.component.scss
+++ b/src/app/components/invitation-list/invitation-list.component.scss
@@ -2,97 +2,69 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the
 // project root for license information.
 
+:host {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px);
+}
+
+.cssLayoutRowStartCenter {
+  min-height: 76px;
+  flex-shrink: 0;
+}
+
 .frame {
   display: flex;
   flex-direction: column;
   flex: 1;
-  height: calc(100vh - 60px);
-  overflow-y: hidden;
-  margin-left: 5px;
+  min-height: 0;
 }
 
-.table {
-  font-size: small;
+.table-container {
+  flex: 1;
+  overflow: auto;
+  padding-bottom: 20px;
+}
+
+table {
   width: 100%;
-  overflow: none;
-  background: transparent;
-}
-
-.header-row {
-  min-height: 40px;
-  background: transparent;
-}
-
-.row {
-  min-height: 36px;
-}
-
-.row,
-.header-row {
-  display: flex;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
-  align-items: center;
-  box-sizing: border-box;
-}
-
-.header-cell {
-  font-size: 14px;
-}
-
-.cell,
-.header-cell {
-  overflow: hidden;
-  word-wrap: break-word;
-  text-align: left;
-  min-width: 120px;
-}
-
-.column-name-name {
-  flex: 0 0 5%;
-  padding: 1%;
-}
-
-.column-name {
-  flex: 0 0 20%;
-  padding: 1%;
 }
 
 .column-action {
   flex: 0 0 150px;
-  flex-direction: row;
-  padding: 0;
-  word-wrap: none;
+  width: 150px;
+  white-space: nowrap;
 }
 
-.column-summary {
-  flex: 0 0 40%;
-  padding: 1%;
-}
-
-.scrolling-region {
-  height: calc(100vh - 89px);
-  overflow: auto;
-  width: 100%;
-}
-
-.template-title {
-  width: 50%;
-}
-
-.action-cell {
+.column-team {
   flex: 2;
-  min-width: 165px;
-  max-width: 165px;
-  text-align: center;
+  min-width: 0;
 }
 
-.number-cell {
+.column-email-domain {
+  flex: 3;
+  min-width: 0;
+}
+
+.column-expires {
+  flex: 2;
+  min-width: 0;
+}
+
+.column-uses {
   flex: 1;
-  text-align: center;
+  min-width: 0;
 }
 
-.little-left {
-  margin-left: 8px;
-  margin-right: 5px;
+.center-self {
+  align-self: center;
+}
+
+.button-end {
+  margin-left: auto;
+}
+
+.no-results {
+  padding: 20px;
+  text-align: center;
 }

--- a/src/app/components/invitation-list/invitation-list.component.ts
+++ b/src/app/components/invitation-list/invitation-list.component.ts
@@ -2,8 +2,8 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the
 // project root for license information.
 import { Component, Input, OnDestroy, ViewChild } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
 import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
 import { Subject, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import {
@@ -14,7 +14,6 @@ import {
 import { MselDataService, MselPlus } from 'src/app/data/msel/msel-data.service';
 import { MselQuery } from 'src/app/data/msel/msel.query';
 import { Sort } from '@angular/material/sort';
-import { MatMenuTrigger } from '@angular/material/menu';
 import { InvitationDataService } from 'src/app/data/invitation/invitation-data.service';
 import { InvitationQuery } from 'src/app/data/invitation/invitation.query';
 import { TeamQuery } from 'src/app/data/team/team.query';
@@ -33,19 +32,13 @@ export class InvitationListComponent implements OnDestroy {
   @Input() loggedInUserId: string;
   @Input() canEditMsel: boolean;
   @Input() hideSearch: boolean;
-  // context menu
-  @ViewChild(MatMenuTrigger, { static: true }) contextMenu: MatMenuTrigger;
-  contextMenuPosition = { x: '0px', y: '0px' };
+  @ViewChild(MatPaginator) set matPaginator(paginator: MatPaginator) {
+    this.invitationDataSource.paginator = paginator;
+  }
   msel = new MselPlus();
   invitationList: Invitation[] = [];
-  changedInvitation: Invitation = {};
-  filteredInvitationList: Invitation[] = [];
-  filterControl = new UntypedFormControl();
   filterString = '';
-  sort: Sort = { active: 'name', direction: 'asc' };
-  sortedInvitations: Invitation[] = [];
-  templateInvitations: Invitation[] = [];
-  editingId = '';
+  sort: Sort = { active: 'teamId', direction: 'asc' };
   invitationDataSource = new MatTableDataSource<Invitation>(new Array<Invitation>());
   displayedColumns: string[] = ['action', 'teamId', 'emailDomain', 'expirationDateTime', 'usesAllowed', 'usesRemaining'];
   teamList: Team[] = [];
@@ -62,33 +55,19 @@ export class InvitationListComponent implements OnDestroy {
     // subscribe to invitations
     this.invitationQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(invitations => {
       this.invitationList = invitations;
-      this.sortChanged(this.sort);
+      this.applyFilter(this.filterString);
     });
     // subscribe to the active MSEL
     (this.mselQuery.selectActive() as Observable<MselPlus>).pipe(takeUntil(this.unsubscribe$)).subscribe(msel => {
       if (msel && this.msel.id !== msel.id) {
         Object.assign(this.msel, msel);
-        this.sortChanged(this.sort);
+        this.applyFilter(this.filterString);
       }
     });
     // subscribe to the MSEL teams
     this.teamQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(teams => {
       this.teamList = teams;
     });
-    // subscribe to filter control changes
-    this.filterControl.valueChanges
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe((term) => {
-        this.filterString = term;
-        this.sortChanged(this.sort);
-      });
-  }
-
-  getSortedInvitations(invitations: Invitation[]) {
-    if (invitations) {
-      invitations.sort((a, b) => this.sortInvitations(a, b, this.sort.active, this.sort.direction));
-    }
-    return invitations;
   }
 
   addOrEditInvitation(invitation: Invitation, makeTemplate: boolean) {
@@ -139,59 +118,44 @@ export class InvitationListComponent implements OnDestroy {
       .subscribe((result) => {
         if (result['confirm']) {
           this.invitationDataService.delete(invitation.id);
-          this.editingId = '';
         }
       });
+  }
+
+  applyFilter(filterValue: string) {
+    this.filterString = filterValue;
+    const term = filterValue.toLowerCase();
+    const filtered = this.invitationList
+      .filter(inv => inv.mselId === this.msel.id)
+      .filter(inv =>
+        !term ||
+        this.getTeamName(inv.teamId)?.toLowerCase().includes(term) ||
+        inv.emailDomain?.toLowerCase().includes(term)
+      )
+      .sort((a, b) => this.sortInvitations(a, b));
+    this.invitationDataSource.data = filtered;
   }
 
   sortChanged(sort: Sort) {
     this.sort = sort;
-    this.invitationDataSource.data = this.getSortedInvitations(this.getFilteredInvitations(this.msel.id, this.invitationList));
+    this.applyFilter(this.filterString);
   }
 
-  ngOnDestroy() {
-    this.unsubscribe$.next(null);
-    this.unsubscribe$.complete();
-  }
-
-  getFilteredInvitations(mselId: string, invitations: Invitation[]): Invitation[] {
-    let filteredInvitations: Invitation[] = [];
-    if (invitations) {
-      invitations.forEach(se => {
-        if (se.mselId === mselId) {
-          filteredInvitations.push({ ...se });
-        }
-      });
-      if (filteredInvitations && filteredInvitations.length > 0 && this.filterString) {
-        const filterString = this.filterString?.toLowerCase();
-        filteredInvitations = filteredInvitations.filter(invitation => {
-          const teamName = this.getTeamName(invitation.teamId)?.toLowerCase() || ''; // Ensuring it's always a string
-          return teamName.includes(filterString) ||
-            invitation.emailDomain?.toLowerCase().includes(filterString) ||
-            (invitation.teamId && invitation.teamId.toString().includes(filterString));
-        });
-      }
-    }
-    return filteredInvitations;
-  }
-
-  private sortInvitations(
-    a: Invitation,
-    b: Invitation,
-    column: string,
-    direction: string
-  ) {
-    const isAsc = direction !== 'desc';
-    switch (column) {
-      // case 'name':
-      //   return ( (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1) );
-      //   break;
-      // case 'shortname':
-      //   return ( (a.shortName.toLowerCase() < b.shortName.toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1) );
-      //   break;
-      // case 'summary':
-      //   return ( (a.summary.toLowerCase() < b.summary.toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1) );
-      //   break;
+  sortInvitations(a: Invitation, b: Invitation): number {
+    const dir = this.sort.direction === 'desc' ? -1 : 1;
+    switch (this.sort.active) {
+      case 'teamId':
+        return (this.getTeamName(a.teamId)?.toLowerCase() ?? '') <
+          (this.getTeamName(b.teamId)?.toLowerCase() ?? '') ? -dir : dir;
+      case 'emailDomain':
+        return (a.emailDomain?.toLowerCase() ?? '') < (b.emailDomain?.toLowerCase() ?? '') ? -dir : dir;
+      case 'expirationDateTime':
+        return (a.expirationDateTime ?? '') < (b.expirationDateTime ?? '') ? -dir : dir;
+      case 'usesAllowed':
+        return (a.maxUsersAllowed ?? 0) < (b.maxUsersAllowed ?? 0) ? -dir : dir;
+      case 'usesRemaining':
+        return ((a.maxUsersAllowed ?? 0) - (a.userCount ?? 0)) <
+          ((b.maxUsersAllowed ?? 0) - (b.userCount ?? 0)) ? -dir : dir;
       default:
         return 0;
     }
@@ -212,4 +176,8 @@ export class InvitationListComponent implements OnDestroy {
     return teamName;
   }
 
+  ngOnDestroy() {
+    this.unsubscribe$.next(null);
+    this.unsubscribe$.complete();
+  }
 }

--- a/src/app/components/msel-contributors/msel-contributors.component.html
+++ b/src/app/components/msel-contributors/msel-contributors.component.html
@@ -3,34 +3,70 @@ Copyright 2024 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license, please see LICENSE.md in the
 project root for license information or contact permission@sei.cmu.edu for full terms.
 -->
+
+<div class="cssLayoutRowStartCenter">
+  <div class="sp-icon">
+    <mat-icon class="mdi-24px" fontIcon="mdi-account-edit" [ngStyle]="{'color': 'var(--mat-sys-primary)'}"></mat-icon>
+  </div>
+  <mat-form-field style="width: 300px; margin-left: 10px;">
+    <input matInput [(ngModel)]="filterString" (keyup)="applyFilter($any($event.target).value)" placeholder="Search" />
+    @if (filterString) {
+    <button mat-icon-button matSuffix (click)="applyFilter('')" title="Clear Search">
+      <mat-icon style="transform: scale(0.85)" fontIcon="mdi-close-circle-outline"></mat-icon>
+    </button>
+    }
+  </mat-form-field>
+  <div class="button-end">
+    <mat-paginator #paginator [pageIndex]="0" [pageSize]="20"
+      [pageSizeOptions]="[5, 10, 15, 20, 25, 50]"></mat-paginator>
+  </div>
+</div>
+
+<mat-menu #addMenu="matMenu" [overlapTrigger]="false">
+  @for (unit of getUnitList(); track unit.id) {
+  <button mat-menu-item (click)="addUnitToMsel(unit.id)" title="Add {{ unit.name }} to MSEL">
+    {{ unit.shortName }} - {{ unit.name }}
+  </button>
+  }
+  @if (getUnitList().length === 0) {
+  <button mat-menu-item disabled>No units available</button>
+  }
+</mat-menu>
+
 @if (msel) {
-<div class="scrolling-region">
+<div class="frame">
   <div class="table-container">
-    <table mat-table #contributorTable [dataSource]="mselUnitDataSource" multiTemplateDataRows>
+    <table mat-table #contributorTable [dataSource]="mselUnitDataSource" matSort (matSortChange)="sortChanged($event)" multiTemplateDataRows>
       <!-- action column -->
       <ng-container matColumnDef="action">
-        <th mat-header-cell *matHeaderCellDef class="column-action">&nbsp;</th>
+        <th mat-header-cell *matHeaderCellDef class="column-action">
+          @if (canManageMsel()) {
+          <button mat-icon-button [matMenuTriggerFor]="addMenu" (menuOpened)="refreshUnits()" title="Add a contributor unit" style="outline: none;">
+            <mat-icon class="mdi-24px center-self" fontIcon="mdi-plus-circle"></mat-icon>
+          </button>
+          }
+        </th>
         <td mat-cell *matCellDef="let element" class="column-action">
           @if (canManageMsel()) {
           <button mat-icon-button (click)="removeUnitFromMsel(element.id); $event.stopPropagation();"
             title="Remove unit from MSEL">
-            <mat-icon class="mdi-24px self-center" fontIcon="mdi-minus-circle-outline"></mat-icon>
+            <mat-icon class="mdi-18px" fontIcon="mdi-minus-circle-outline"></mat-icon>
           </button>
           }
         </td>
       </ng-container>
       <!-- shortName Column -->
       <ng-container matColumnDef="shortName">
-        <th mat-header-cell *matHeaderCellDef class="column-short-name">Short Name</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-short-name">Short Name</th>
         <td mat-cell *matCellDef="let element" class="column-short-name">
-          {{ getUnit(element.unitId).shortName }}
+          {{ element.unit?.shortName }}
         </td>
       </ng-container>
       <!-- name Column -->
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef class="column-name">Name</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-name">Name</th>
         <td mat-cell *matCellDef="let element" class="column-name">
-          {{ getUnit(element.unitId).name }}
+          {{ element.unit?.name }}
         </td>
       </ng-container>
       <!-- Expanded Content Column -->
@@ -67,22 +103,5 @@ project root for license information or contact permission@sei.cmu.edu for full 
       <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
     </table>
   </div>
-  @if (canManageMsel()) {
-  <div class="add-unit-container">
-    <mat-expansion-panel>
-      <mat-expansion-panel-header (click)="$event.stopPropagation();">
-        Add a Contributor Unit
-      </mat-expansion-panel-header>
-      @for (unit of getUnitList(); track unit) {
-      <div class="other-units-div">
-        <button mat-icon-button (click)="addUnitToMsel(unit.id); $event.stopPropagation();" title="Add unit to MSEL">
-          <mat-icon class="mdi-24px self-center" fontIcon="mdi-plus-circle-outline"></mat-icon>
-        </button>
-        <span class="center-self">{{ unit.shortName }} - {{ unit.name }}</span>
-      </div>
-      }
-    </mat-expansion-panel>
-  </div>
-  }
 </div>
 }

--- a/src/app/components/msel-contributors/msel-contributors.component.scss
+++ b/src/app/components/msel-contributors/msel-contributors.component.scss
@@ -2,17 +2,28 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the
 // project root for license information.
 
-.scrolling-region {
-  width: 100%;
-  height: calc(100vh - 60px);
-  overflow: auto;
+:host {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  height: calc(100vh - 60px);
+}
+
+.cssLayoutRowStartCenter {
+  min-height: 76px;
+  flex-shrink: 0;
+}
+
+.frame {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
 .table-container {
-  width: 100%;
+  flex: 1;
+  overflow: auto;
+  padding-bottom: 20px;
 }
 
 table {
@@ -46,13 +57,13 @@ table {
 }
 
 .column-name {
-  flex: 0 0 calc(80% - 100px);
+  flex: 1;
+  min-width: 0;
   padding: 2px;
 }
 
 .expanded-detail-div {
   width: calc(100% - 20px);
-  min-width: 660px;
   margin-left: 20px;
   max-height: 500px;
   overflow: auto;
@@ -65,20 +76,8 @@ table {
   width: 100%;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   flex: 1;
-}
-
-.other-units-div {
-  display: flex;
-  flex-direction: row;
-  text-align: left;
-  margin-left: 50px;
-  width: calc(100% - 50px);
-}
-
-.add-unit-container {
-  width: 100%;
-  padding: 10px;
 }
 
 .user-name {
@@ -91,12 +90,18 @@ table {
 
 .four-cell {
   flex: 4;
+  min-width: 150px;
 }
 
 .one-cell {
   flex: 1;
+  min-width: 100px;
 }
 
 .center-self {
   align-self: center;
+}
+
+.button-end {
+  margin-left: auto;
 }

--- a/src/app/components/msel-contributors/msel-contributors.component.ts
+++ b/src/app/components/msel-contributors/msel-contributors.component.ts
@@ -4,6 +4,7 @@
 import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Subject, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { UnitDataService } from 'src/app/data/unit/unit-data.service';
 import { UnitQuery } from 'src/app/data/unit/unit.query';
 import { UserQuery } from 'src/app/data/user/user.query';
 import {
@@ -26,6 +27,8 @@ import { UserMselRoleDataService } from 'src/app/data/user-msel-role/user-msel-r
 import { UserMselRoleQuery } from 'src/app/data/user-msel-role/user-msel-role.query';
 import { DialogService } from 'src/app/services/dialog/dialog.service';
 import { MatTable, MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 
 @Component({
@@ -46,7 +49,12 @@ export class MselContributorsComponent implements OnDestroy, OnInit {
   // context menu
   @ViewChild(MatMenuTrigger, { static: true }) contextMenu: MatMenuTrigger;
   @ViewChild('contributorTable', { static: false }) contributorTable: MatTable<any>;
+  @ViewChild(MatPaginator) set matPaginator(paginator: MatPaginator) {
+    this.mselUnitDataSource.paginator = paginator;
+  }
   contextMenuPosition = { x: '0px', y: '0px' };
+  filterString = '';
+  sort: Sort = { active: 'shortName', direction: 'asc' };
   msel = new MselPlus();
   originalMsel = new MselPlus();
   expandedSectionIds: string[] = [];
@@ -72,6 +80,7 @@ export class MselContributorsComponent implements OnDestroy, OnInit {
   private unsubscribe$ = new Subject();
 
   constructor(
+    private unitDataService: UnitDataService,
     private unitQuery: UnitQuery,
     private userQuery: UserQuery,
     private mselDataService: MselDataService,
@@ -111,11 +120,7 @@ export class MselContributorsComponent implements OnDestroy, OnInit {
           this.mselUnitList.push(Object.assign(mselUnit, mt));
         }
       });
-      if (this.mselUnitList.length > 0) {
-        this.mselUnitList = this.mselUnitList.sort((a, b) =>
-          a.unit.shortName?.toLowerCase() > b.unit.shortName?.toLowerCase() ? 1 : -1);
-      }
-      this.mselUnitDataSource.data = this.mselUnitList;
+      this.applyFilter(this.filterString);
     });
     // subscribe to UserMselRoles
     this.userMselRoleQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(umrs => {
@@ -124,6 +129,8 @@ export class MselContributorsComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit() {
+    // Refresh units so newly created units appear in the add menu
+    this.unitDataService.load();
     // Load permissions and trigger change detection when loaded
     this.permissionDataService.load()
       .pipe(takeUntil(this.unsubscribe$))
@@ -156,6 +163,10 @@ export class MselContributorsComponent implements OnDestroy, OnInit {
     }
 
     return unitList;
+  }
+
+  refreshUnits() {
+    this.unitDataService.load();
   }
 
   getUnit(id: string) {
@@ -278,12 +289,40 @@ export class MselContributorsComponent implements OnDestroy, OnInit {
   }
 
   isOwnOwnerRole(userId: string, mselRole: MselRole): boolean {
-    return userId === this.loggedInUserId && mselRole === MselRole.Owner;
+    return userId === this.loggedInUserId && mselRole === MselRole.Owner && this.hasMselRole(userId, mselRole);
   }
 
   ngOnDestroy() {
     this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
+  }
+
+  applyFilter(filterValue: string) {
+    this.filterString = filterValue;
+    filterValue = filterValue.toLowerCase();
+    const filtered = this.mselUnitList
+      .filter(mu =>
+        mu.unit?.name?.toLowerCase().includes(filterValue) ||
+        mu.unit?.shortName?.toLowerCase().includes(filterValue) ||
+        mu.unit?.users?.some(u => u.name?.toLowerCase().includes(filterValue))
+      )
+      .sort((a, b) => this.sortMselUnits(a, b));
+    this.mselUnitDataSource.data = filtered;
+  }
+
+  sortChanged(sort: Sort) {
+    this.sort = sort;
+    this.applyFilter(this.filterString);
+  }
+
+  sortMselUnits(a: MselUnit, b: MselUnit): number {
+    const dir = this.sort.direction === 'desc' ? -1 : 1;
+    switch (this.sort.active) {
+      case 'name':
+        return (a.unit?.name?.toLowerCase() ?? '') < (b.unit?.name?.toLowerCase() ?? '') ? -dir : dir;
+      default:
+        return (a.unit?.shortName?.toLowerCase() ?? '') < (b.unit?.shortName?.toLowerCase() ?? '') ? -dir : dir;
+    }
   }
 
   getRoleDescription(role: MselRole): string {

--- a/src/app/components/msel-teams/msel-teams.component.html
+++ b/src/app/components/msel-teams/msel-teams.component.html
@@ -32,12 +32,12 @@ project root for license information or contact permission@sei.cmu.edu for full 
 @if (msel) {
 <div class="frame">
   <div class="table-container">
-    <table mat-table #teamTable [dataSource]="teamDataSource" multiTemplateDataRows>
+    <table mat-table #teamTable [dataSource]="teamDataSource" matSort (matSortChange)="sortChanged($event)" multiTemplateDataRows>
       <!-- action column -->
       <ng-container matColumnDef="action">
         <th mat-header-cell *matHeaderCellDef class="column-action">
           @if (canEditMsel()) {
-          <button mat-icon-button [matMenuTriggerFor]="addMenu" title="Add a team" style="outline: none;">
+          <button mat-icon-button [matMenuTriggerFor]="addMenu" (menuOpened)="refreshUnits()" title="Add a team" style="outline: none;">
             <mat-icon class="mdi-24px center-self" fontIcon="mdi-plus-circle"></mat-icon>
           </button>
           }
@@ -56,32 +56,38 @@ project root for license information or contact permission@sei.cmu.edu for full 
           }
         </td>
       </ng-container>
+      <!-- shortName column -->
+      <ng-container matColumnDef="shortName">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-short-name">Short Name</th>
+        <td mat-cell *matCellDef="let element" class="column-short-name">
+          {{ element.shortName }}
+        </td>
+      </ng-container>
       <!-- name column -->
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef class="column-name">Name</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-name">Name</th>
         <td mat-cell *matCellDef="let element" class="column-name">
-          {{ element.shortName }} - {{ element.name }}
+          {{ element.name }}
         </td>
       </ng-container>
       <!-- email column -->
       <ng-container matColumnDef="email">
-        <th mat-header-cell *matHeaderCellDef class="column-email">Email</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-email">Email</th>
         <td mat-cell *matCellDef="let element" class="column-email">{{ element.email }}</td>
       </ng-container>
       <!-- teamType column -->
       <ng-container matColumnDef="teamType">
-        <th mat-header-cell *matHeaderCellDef class="column-team-type">Team Type</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="column-team-type">Team Type</th>
         <td mat-cell *matCellDef="let element" class="column-team-type">
           {{ getCiteTeamTypeName(element.citeTeamTypeId) }}
         </td>
       </ng-container>
       <!-- invitation column -->
       <ng-container matColumnDef="invitation">
-        <th mat-header-cell *matHeaderCellDef class="column-invitation">Invitation</th>
+        <th mat-header-cell *matHeaderCellDef class="column-invitation">Open Invite</th>
         <td mat-cell *matCellDef="let element" class="column-invitation">
-          @if (element.canTeamMemberInvite) {
-          <span>** ALL can invite</span>
-          }&nbsp;
+          <mat-checkbox [checked]="element.canTeamMemberInvite" disabled
+            (click)="$event.stopPropagation();" matTooltip="Any team member can invite"></mat-checkbox>
         </td>
       </ng-container>
       <!-- Expanded Content Column -->

--- a/src/app/components/msel-teams/msel-teams.component.scss
+++ b/src/app/components/msel-teams/msel-teams.component.scss
@@ -53,8 +53,13 @@ table {
   width: 120px;
 }
 
+.column-short-name {
+  flex: 2;
+  min-width: 0;
+}
+
 .column-name {
-  flex: 5;
+  flex: 4;
   min-width: 0;
 }
 

--- a/src/app/components/msel-teams/msel-teams.component.ts
+++ b/src/app/components/msel-teams/msel-teams.component.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the
 // project root for license information.
-import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Subject, Observable } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { TeamDataService } from 'src/app/data/team/team-data.service';
@@ -25,9 +25,11 @@ import { MatDialog } from '@angular/material/dialog';
 import { DialogService } from 'src/app/services/dialog/dialog.service';
 import { TeamAddDialogComponent } from '../team-add-dialog/team-add-dialog.component';
 import { TeamEditDialogComponent } from '../team-edit-dialog/team-edit-dialog.component';
+import { UnitDataService } from 'src/app/data/unit/unit-data.service';
 import { UnitQuery } from 'src/app/data/unit/unit.query';
 import { MatTable, MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 
 @Component({
@@ -43,14 +45,17 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
     ],
     standalone: false
 })
-export class MselTeamsComponent implements OnDestroy, OnInit, AfterViewInit {
+export class MselTeamsComponent implements OnDestroy, OnInit {
   @Input() loggedInUserId: string;
   @Input() teamTypeList: TeamType[];
   // context menu
   @ViewChild(MatMenuTrigger, { static: true }) contextMenu: MatMenuTrigger;
   @ViewChild('teamTable', { static: false }) teamTable: MatTable<any>;
-  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatPaginator) set matPaginator(paginator: MatPaginator) {
+    this.teamDataSource.paginator = paginator;
+  }
   contextMenuPosition = { x: '0px', y: '0px' };
+  sort: Sort = { active: 'name', direction: 'asc' };
   msel = new MselPlus();
   originalMsel = new MselPlus();
   expandedSectionIds: string[] = [];
@@ -63,7 +68,7 @@ export class MselTeamsComponent implements OnDestroy, OnInit, AfterViewInit {
   unitList: Unit[] = [];
   filterString = '';
   teamDataSource = new MatTableDataSource<Team>(new Array<Team>());
-  displayedColumns: string[] = ['action', 'name', 'email', 'teamType', 'invitation'];
+  displayedColumns: string[] = ['action', 'shortName', 'name', 'email', 'teamType', 'invitation'];
   expandedElementId = '';
   isExpansionDetailRow = (i: number, row: Object) => (row as Team).id === this.expandedElementId;
   private allTeams: Team[] = [];
@@ -76,6 +81,7 @@ export class MselTeamsComponent implements OnDestroy, OnInit, AfterViewInit {
     private mselDataService: MselDataService,
     private mselQuery: MselQuery,
     private citeService: CiteService,
+    private unitDataService: UnitDataService,
     private unitQuery: UnitQuery,
     private dialog: MatDialog,
     public dialogService: DialogService,
@@ -87,8 +93,7 @@ export class MselTeamsComponent implements OnDestroy, OnInit, AfterViewInit {
       if (msel && this.msel.id !== msel.id) {
         Object.assign(this.originalMsel, msel);
         Object.assign(this.msel, msel);
-        this.teamList = this.allTeams.filter(t => t.mselId === this.msel.id);
-        this.teamDataSource.data = this.teamList;
+        this.applyFilter(this.filterString);
       }
     });
     // subscribe to users
@@ -98,9 +103,8 @@ export class MselTeamsComponent implements OnDestroy, OnInit, AfterViewInit {
     // subscribe to teams
     this.teamQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(teams => {
       if (teams && teams.length > 0) {
-        this.allTeams = teams.sort((a, b) => a.shortName?.toLowerCase() > b.shortName?.toLowerCase() ? 1 : -1);
-        this.teamList = this.allTeams.filter(t => t.mselId === this.msel.id);
-        this.teamDataSource.data = this.teamList;
+        this.allTeams = teams;
+        this.applyFilter(this.filterString);
       }
     });
     // subscribe to TeamTypes
@@ -130,9 +134,6 @@ export class MselTeamsComponent implements OnDestroy, OnInit, AfterViewInit {
       });
   }
 
-  ngAfterViewInit() {
-    this.teamDataSource.paginator = this.paginator;
-  }
 
   getUserName(userId: string) {
     const user = this.userList.find(u => u.id === userId);
@@ -222,11 +223,15 @@ export class MselTeamsComponent implements OnDestroy, OnInit, AfterViewInit {
       });
   }
 
+  refreshUnits() {
+    this.unitDataService.load();
+  }
+
   addTeamFromUnit() {
     const dialogRef = this.dialog.open(TeamAddDialogComponent, {
-      minWidth: '400px',
+      minWidth: '500px',
       maxWidth: '90vw',
-      width: 'auto',
+      width: '600px',
       maxHeight: '80vh',
       data: {
         unitList: this.unitList
@@ -265,8 +270,29 @@ export class MselTeamsComponent implements OnDestroy, OnInit, AfterViewInit {
       .filter(team =>
         team.mselId === this.msel.id &&
         (team.name.toLowerCase().indexOf(filterValue) >= 0 ||
-          team.shortName.toLowerCase().indexOf(filterValue) >= 0));
+          team.shortName.toLowerCase().indexOf(filterValue) >= 0))
+      .sort((a, b) => this.sortTeams(a, b));
     this.teamDataSource.data = this.teamList;
+  }
+
+  sortChanged(sort: Sort) {
+    this.sort = sort;
+    this.applyFilter(this.filterString);
+  }
+
+  sortTeams(a: Team, b: Team): number {
+    const dir = this.sort.direction === 'desc' ? -1 : 1;
+    switch (this.sort.active) {
+      case 'name':
+        return (a.name?.toLowerCase() ?? '') < (b.name?.toLowerCase() ?? '') ? -dir : dir;
+      case 'email':
+        return (a.email?.toLowerCase() ?? '') < (b.email?.toLowerCase() ?? '') ? -dir : dir;
+      case 'teamType':
+        return (this.getCiteTeamTypeName(a.citeTeamTypeId)?.toLowerCase() ?? '') <
+          (this.getCiteTeamTypeName(b.citeTeamTypeId)?.toLowerCase() ?? '') ? -dir : dir;
+      default:
+        return (a.shortName?.toLowerCase() ?? '') < (b.shortName?.toLowerCase() ?? '') ? -dir : dir;
+    }
   }
 
   rowClicked(row: Team) {

--- a/src/app/components/organization-list/organization-list.component.ts
+++ b/src/app/components/organization-list/organization-list.component.ts
@@ -225,13 +225,13 @@ export class OrganizationListComponent implements OnDestroy, OnInit, AfterViewIn
     const isAsc = direction !== 'desc';
     switch (column) {
       case 'name':
-        return ((a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
+        return (((a.name ?? '').toLowerCase() < (b.name ?? '').toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
         break;
       case 'shortname':
-        return ((a.shortName.toLowerCase() < b.shortName.toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
+        return (((a.shortName ?? '').toLowerCase() < (b.shortName ?? '').toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
         break;
       case 'summary':
-        return ((a.summary.toLowerCase() < b.summary.toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
+        return (((a.summary ?? '').toLowerCase() < (b.summary ?? '').toLowerCase() ? -1 : 1) * (isAsc ? 1 : -1));
         break;
       default:
         return 0;

--- a/src/app/components/team-add-dialog/team-add-dialog.component.html
+++ b/src/app/components/team-add-dialog/team-add-dialog.component.html
@@ -19,28 +19,20 @@ project root for license information or contact permission@sei.cmu.edu for full 
 @if (!!data && !!data.unitList) {
   <div mat-dialog-content>
     <div class="all-content">
-      <div class="search-div">
-        <mat-form-field class="search-control">
-          <mat-label>Search</mat-label>
-          <input
-            matInput
-            [(ngModel)]="filterString"
-            (keyup)="applyFilter($any($event.target).value)"
-            placeholder="Search"
-            />
-        </mat-form-field>
-        <div style="width: 30px;">
-          <button
-            mat-icon-button
-            (click)="applyFilter('')"
-            style="outline: none;"
-            title="Clear Search"
-            [disabled]="!filterString"
-            >
-            <mat-icon class="mdi-24px self-center" fontIcon="mdi-close-circle-outline"></mat-icon>
-          </button>
-        </div>
-      </div>
+      <mat-form-field class="search-control">
+        <mat-label>Search</mat-label>
+        <input
+          matInput
+          [(ngModel)]="filterString"
+          (keyup)="applyFilter($any($event.target).value)"
+          placeholder="Search"
+          />
+        @if (filterString) {
+        <button mat-icon-button matSuffix (click)="applyFilter('')" title="Clear Search">
+          <mat-icon style="transform: scale(0.85)" fontIcon="mdi-close-circle-outline"></mat-icon>
+        </button>
+        }
+      </mat-form-field>
       <div class="unit-list-div">
         @for (unit of filteredList(); track unit) {
           <div class="unit-div">
@@ -53,6 +45,3 @@ project root for license information or contact permission@sei.cmu.edu for full 
     </div>
   </div>
 }
-<div mat-dialog-actions class="action-buttons">
-  <button mat-stroked-button (click)="handleEditComplete(null)">Cancel</button>
-</div>

--- a/src/app/components/team-add-dialog/team-add-dialog.component.scss
+++ b/src/app/components/team-add-dialog/team-add-dialog.component.scss
@@ -16,12 +16,13 @@
 
 .unit-div {
   margin-bottom: 10px;
-  width: 80%;
+  width: 100%;
 }
 
 .unit-button {
   width: 90%;
   text-align: left;
+  white-space: nowrap;
 }
 
 .full-width {
@@ -57,16 +58,6 @@
   float: right;
 }
 
-.search-div {
-  display: flex;
-  flex-flow: row;
-  width: 50%;
-}
-
 .search-control {
-  width: calc(100% - 32px);
-}
-
-.action-buttons{
-  max-height: 70px !important;
+  width: 90%;
 }

--- a/src/app/services/signalr.service.ts
+++ b/src/app/services/signalr.service.ts
@@ -27,6 +27,7 @@ import {
   ScenarioEvent,
   Team,
   TeamUser,
+  Unit,
   User,
   UserMselRole,
 } from 'src/app/generated/blueprint.api';
@@ -43,6 +44,7 @@ import { InjectTypeDataService } from '../data/inject-type/inject-type-data.serv
 import { MoveDataService } from '../data/move/move-data.service';
 import { MselDataService } from '../data/msel/msel-data.service';
 import { MselUnitDataService } from '../data/msel-unit/msel-unit-data.service';
+import { UnitDataService } from '../data/unit/unit-data.service';
 import { OrganizationDataService } from '../data/organization/organization-data.service';
 import { PlayerApplicationDataService } from '../data/player-application/player-application-data.service';
 import { PlayerApplicationTeamDataService } from '../data/team/player-application-team-data.service';
@@ -96,6 +98,7 @@ export class SignalRService implements OnDestroy {
     private moveDataService: MoveDataService,
     private mselDataService: MselDataService,
     private mselUnitDataService: MselUnitDataService,
+    private unitDataService: UnitDataService,
     private organizationDataService: OrganizationDataService,
     private playerApplicationDataService: PlayerApplicationDataService,
     private playerApplicationTeamDataService: PlayerApplicationTeamDataService,
@@ -230,6 +233,8 @@ export class SignalRService implements OnDestroy {
     this.addMoveHandlers();
     this.addMselHandlers();
     this.addMselUnitHandlers();
+    this.addUnitHandlers();
+    this.addUnitUserHandlers();
     this.addOrganizationHandlers();
     this.addPlayerApplicationHandlers();
     this.addPlayerApplicationTeamHandlers();
@@ -424,6 +429,40 @@ export class SignalRService implements OnDestroy {
 
     this.hubConnection.on('MselUnitDeleted', (id: string) => {
       this.mselUnitDataService.deleteFromStore(id);
+    });
+  }
+
+  private addUnitHandlers() {
+    this.hubConnection.on('UnitCreated', (unit: Unit) => {
+      this.unitDataService.updateStore(unit);
+    });
+
+    this.hubConnection.on('UnitUpdated', (unit: Unit) => {
+      this.unitDataService.updateStore(unit);
+      if (this.mselId) {
+        this.mselUnitDataService.loadByMsel(this.mselId);
+      }
+    });
+
+    this.hubConnection.on('UnitDeleted', (id: string) => {
+      this.unitDataService.deleteFromStore(id);
+      if (this.mselId) {
+        this.mselUnitDataService.loadByMsel(this.mselId);
+      }
+    });
+  }
+
+  private addUnitUserHandlers() {
+    this.hubConnection.on('UnitUserCreated', (unitUser: any) => {
+      if (this.mselId) {
+        this.mselUnitDataService.loadByMsel(this.mselId);
+      }
+    });
+
+    this.hubConnection.on('UnitUserDeleted', (unitUser: any) => {
+      if (this.mselId) {
+        this.mselUnitDataService.loadByMsel(this.mselId);
+      }
     });
   }
 


### PR DESCRIPTION
- Restyle contributors page to match standard MSEL builder layout
- Add sortable columns to contributors, teams, and invitations tables
- Split teams name into separate short name and name columns
- Restyle invitations page with standard toolbar, paginator, and mat-table
- Change teams invitation column to checkbox with Open Invite label
- Add SignalR handlers for Unit and UnitUser events
- Fix owner checkbox showing unchecked when user is owner
- Fix team-add-dialog duplicate cancel button and search field
- Refresh units on add menu open for fresh data