### PR TITLE
Standardize spinner styling and placement

### DIFF
--- a/src/app/components/admin/admin-users/admin-user-list/admin-user-list.component.html
+++ b/src/app/components/admin/admin-users/admin-user-list/admin-user-list.component.html
@@ -95,7 +95,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   </table>
 
   @if (isLoading) {
-    <mat-card style="display: flex; justify-content: center; align-items: center">
+    <mat-card appearance="outlined" style="display: flex; justify-content: center; align-items: center">
       <mat-progress-spinner color="primary" mode="indeterminate">
       </mat-progress-spinner>
     </mat-card>

--- a/src/app/components/msel-list/msel-list.component.html
+++ b/src/app/components/msel-list/msel-list.component.html
@@ -59,12 +59,6 @@ project root for license information or contact permission@sei.cmu.edu for full 
         </mat-form-field>
       </div>
     </div>
-    @if (isLoading) {
-    <mat-card appearance="outlined" style="display: flex; justify-content: center; align-items: center">
-      <mat-progress-spinner color="primary" mode="indeterminate">
-      </mat-progress-spinner>
-    </mat-card>
-    }
     <div class="mat-table">
       <mat-table #table [dataSource]="mselDataSource" matSort>
         <!-- action column -->
@@ -187,6 +181,12 @@ project root for license information or contact permission@sei.cmu.edu for full 
       <div class="text no-results">No results found</div>
       }
     </div>
+    @if (isLoading) {
+    <mat-card appearance="outlined" style="display: flex; justify-content: center; align-items: center">
+      <mat-progress-spinner color="primary" mode="indeterminate">
+      </mat-progress-spinner>
+    </mat-card>
+    }
   </div>
 
 <input hidden (change)="selectFile($event)" #xlsxInput type="file" accept=".xlsx" />


### PR DESCRIPTION
  ## Summary                              
  - Move MSEL list loading spinner from above to below content for consistency across Crucible UI apps                                                                                                                                                                  
  - Add `appearance="outlined"` to admin user list spinner to fix background color mismatch with page theme                                                                                                                                                             