### PR TITLE
Fix competency framework count refresh

### DIFF
--- a/src/app/components/admin/admin-competency-frameworks/admin-competency-frameworks.component.html
+++ b/src/app/components/admin/admin-competency-frameworks/admin-competency-frameworks.component.html
@@ -121,12 +121,17 @@ project root for license information or contact permission@sei.cmu.edu for full 
         <div [@detailExpand]="element.id == expandedElementId ? 'expanded' : 'collapsed'" style="overflow: hidden">
           @if (expandedElementId === element.id) {
           <!-- Work Roles -->
-          @if (workRoles.length > 0 || canEdit) {
+          @if (loadingCompetencies || workRoles.length > 0 || canEdit) {
           <mat-expansion-panel class="section-panel">
             <mat-expansion-panel-header>
               <mat-panel-title>
                 <mat-icon class="mdi-18px panel-icon" fontIcon="mdi-account-hard-hat"></mat-icon>
-                Work Roles ({{ workRoles.length }})
+                Work Roles
+                @if (loadingCompetencies) {
+                (Loading...)
+                } @else {
+                ({{ workRoles.length }})
+                }
               </mat-panel-title>
             </mat-expansion-panel-header>
             <div class="element-toolbar" (click)="$event.stopPropagation();">
@@ -327,7 +332,9 @@ project root for license information or contact permission@sei.cmu.edu for full 
                   (click)="toggleCompetencyExpand(row)"></mat-row>
                 <mat-row *matRowDef="let row; columns: ['relatedDetail']" class="detail-row"></mat-row>
               </mat-table>
-              @if (workRoleDataSource.filteredData.length === 0) {
+              @if (loadingCompetencies) {
+                <div class="no-results-inline">Loading work roles...</div>
+              } @else if (workRoleDataSource.filteredData.length === 0) {
                 <div class="no-results-inline">No work roles found</div>
               }
             </div>
@@ -338,7 +345,12 @@ project root for license information or contact permission@sei.cmu.edu for full 
             <mat-expansion-panel-header>
               <mat-panel-title>
                 <mat-icon class="mdi-18px panel-icon" fontIcon="mdi-certificate-outline"></mat-icon>
-                Competencies ({{ expandedCompetencies.length }})
+                Competencies
+                @if (loadingCompetencies) {
+                (Loading...)
+                } @else {
+                ({{ expandedCompetencies.length }})
+                }
               </mat-panel-title>
             </mat-expansion-panel-header>
             <div class="element-toolbar" (click)="$event.stopPropagation();">
@@ -539,7 +551,9 @@ project root for license information or contact permission@sei.cmu.edu for full 
                   (click)="toggleCompetencyExpand(row)"></mat-row>
                 <mat-row *matRowDef="let row; columns: ['relatedDetail']" class="detail-row"></mat-row>
               </mat-table>
-              @if (competencyDataSource.filteredData.length === 0) {
+              @if (loadingCompetencies) {
+                <div class="no-results-inline">Loading competencies...</div>
+              } @else if (competencyDataSource.filteredData.length === 0) {
                 <div class="no-results-inline">No competencies found</div>
               }
             </div>

--- a/src/app/components/admin/admin-competency-frameworks/admin-competency-frameworks.component.ts
+++ b/src/app/components/admin/admin-competency-frameworks/admin-competency-frameworks.component.ts
@@ -56,6 +56,7 @@ export class AdminCompetencyFrameworksComponent implements OnDestroy, AfterViewI
   private unsubscribe$ = new Subject();
   isExpansionDetailRow = (i: number, row: Object) => (row as CompetencyFramework).id === this.expandedElementId;
   expandedElementId = '';
+  loadingCompetencies = false;
   // Competency data sources
   expandedCompetencies: Competency[] = [];
   competencyDataSource = new MatTableDataSource<Competency>([]);
@@ -389,12 +390,8 @@ export class AdminCompetencyFrameworksComponent implements OnDestroy, AfterViewI
 
   rowClicked(row: CompetencyFramework) {
     if (this.expandedElementId === row.id) {
-      this.collapseCompetencyDetail();
       this.expandedElementId = '';
-      this.expandedCompetencies = [];
-      this.competencyDataSource.data = [];
-      this.workRoles = [];
-      this.workRoleDataSource.data = [];
+      this.clearExpandedFrameworkState();
     } else {
       this.expandedElementId = row.id;
       this.loadCompetencies(row.id);
@@ -415,38 +412,72 @@ export class AdminCompetencyFrameworksComponent implements OnDestroy, AfterViewI
   // --- Competencies ---
 
   loadCompetencies(frameworkId: string) {
+    this.clearExpandedFrameworkState();
+    this.loadingCompetencies = true;
     this.competencyFilterControl.setValue('');
     this.workRoleFilterControl.setValue('');
     this.selectedCompetencyType = '';
     this.selectedWorkRoleCategory = '';
     this.competencyFrameworkService.getCompetencyFramework(frameworkId)
       .pipe(take(1))
-      .subscribe(fw => {
-        const allComps = fw.competencies || [];
-        this.buildTypeMap(fw);
-        // Separate work roles from other competencies
-        this.workRoles = allComps.filter(c => this.competencyTypeMap.get(c.id) === 'Work Role');
-        this.expandedCompetencies = allComps.filter(c => this.competencyTypeMap.get(c.id) !== 'Work Role');
-        this.workRoleCategories = [...new Set(this.workRoles.map(wr => this.getWorkRoleCategory(wr)).filter(c => c))].sort();
-        this.applyWorkRoleFilter();
-        this.applyCompetencyFilter();
-        // Refresh expanded row's related data with updated inverse relationships
-        if (this.expandedCompetencyId && this.competencyById.has(this.expandedCompetencyId)) {
-          const fresh = this.competencyById.get(this.expandedCompetencyId);
-          this.expandedComp = fresh;
-          this.currentRelatedIdNumbers = [...(fresh.relatedIdNumbers || [])];
+      .subscribe({
+        next: (fw) => {
+          if (this.expandedElementId !== frameworkId) {
+            return;
+          }
+          this.loadingCompetencies = false;
+          const allComps = fw.competencies || [];
+          this.buildTypeMap(fw);
+          // Separate work roles from other competencies
+          this.workRoles = allComps.filter(c => this.competencyTypeMap.get(c.id) === 'Work Role');
+          this.expandedCompetencies = allComps.filter(c => this.competencyTypeMap.get(c.id) !== 'Work Role');
+          this.workRoleCategories = [...new Set(this.workRoles.map(wr => this.getWorkRoleCategory(wr)).filter(c => c))].sort();
+          this.applyWorkRoleFilter();
+          this.applyCompetencyFilter();
+          // Refresh expanded row's related data with updated inverse relationships
+          if (this.expandedCompetencyId && this.competencyById.has(this.expandedCompetencyId)) {
+            const fresh = this.competencyById.get(this.expandedCompetencyId);
+            this.expandedComp = fresh;
+            this.currentRelatedIdNumbers = [...(fresh.relatedIdNumbers || [])];
 
-          this.updateRelatedDataSources();
+            this.updateRelatedDataSources();
+          }
+          setTimeout(() => {
+            if (this.competencyPaginator) {
+              this.competencyDataSource.paginator = this.competencyPaginator;
+            }
+            if (this.workRolePaginator) {
+              this.workRoleDataSource.paginator = this.workRolePaginator;
+            }
+          });
+        },
+        error: (err: any) => {
+          if (this.expandedElementId !== frameworkId) {
+            return;
+          }
+          this.loadingCompetencies = false;
+          this.importError = 'Load failed: ' + (err.error?.title || err.message || 'Unknown error');
         }
-        setTimeout(() => {
-          if (this.competencyPaginator) {
-            this.competencyDataSource.paginator = this.competencyPaginator;
-          }
-          if (this.workRolePaginator) {
-            this.workRoleDataSource.paginator = this.workRolePaginator;
-          }
-        });
       });
+  }
+
+  private clearExpandedFrameworkState(): void {
+    this.loadingCompetencies = false;
+    this.collapseCompetencyDetail();
+    this.expandedCompetencies = [];
+    this.competencyDataSource.data = [];
+    this.competencyTypes = [];
+    this.workRoles = [];
+    this.workRoleDataSource.data = [];
+    this.workRoleCategories = [];
+    this.taxonomyLevels = [];
+    this.competencyTypeMap.clear();
+    this.competencyById.clear();
+    this.availableRelatedDataSource.data = [];
+    this.relatedDataSource.data = [];
+    this.availableTypes = [];
+    this.relatedTypes = [];
+    this.currentRelatedIdNumbers = [];
   }
 
   private buildTypeMap(fw: CompetencyFramework) {
@@ -513,6 +544,8 @@ export class AdminCompetencyFrameworksComponent implements OnDestroy, AfterViewI
     }
     // NICE 2017: XX-YYY-NNN pattern (3 hyphenated parts) → Work Role
     if (/^[A-Z]{2}-[A-Z]{3}-\d+$/.test(idNumber)) return 'Work Role';
+    // DCWF: category code + role number (for example IT-411, DA-422)
+    if (/^[A-Z]{2}-\d+[A-Z]?$/.test(idNumber)) return 'Work Role';
     // 3-letter code → Specialty Area (e.g. DEV, MGT, ASA)
     if (/^[A-Z]{3}$/.test(idNumber)) return 'Specialty Area';
     // 2-letter code → Category (e.g. PD, IO, AN)

--- a/src/app/components/competency-options-dialog/competency-options-dialog.component.ts
+++ b/src/app/components/competency-options-dialog/competency-options-dialog.component.ts
@@ -113,6 +113,7 @@ export class CompetencyOptionsDialogComponent implements OnDestroy {
       return prefixMap[idNumber.charAt(0)] || 'Other';
     }
     if (/^[A-Z]{2}-[A-Z]{3}-\d+$/.test(idNumber)) return 'Work Role';
+    if (/^[A-Z]{2}-\d+[A-Z]?$/.test(idNumber)) return 'Work Role';
     if (/^[A-Z]{3}$/.test(idNumber)) return 'Specialty Area';
     if (/^[A-Z]{2}$/.test(idNumber)) return 'Category';
     return 'Other';

--- a/src/app/components/msel-competencies/msel-competencies.component.ts
+++ b/src/app/components/msel-competencies/msel-competencies.component.ts
@@ -259,6 +259,7 @@ export class MselCompetenciesComponent implements OnDestroy, OnInit, AfterViewIn
       return prefixMap[idNumber.charAt(0)] || 'Other';
     }
     if (/^[A-Z]{2}-[A-Z]{3}-\d+$/.test(idNumber)) return 'Work Role';
+    if (/^[A-Z]{2}-\d+[A-Z]?$/.test(idNumber)) return 'Work Role';
     if (/^[A-Z]{3}$/.test(idNumber)) return 'Specialty Area';
     if (/^[A-Z]{2}$/.test(idNumber)) return 'Category';
     return 'Other';


### PR DESCRIPTION
## Summary
- clear expanded competency framework state immediately when switching rows
- ignore stale framework-detail responses when users switch rows quickly
- show loading labels instead of stale Work Role/Competency counts
- recognize DCWF role codes like IT-411 as Work Role entries

## Verification
- npm run build
- focused Playwright regression passed for stale count switching