### PR TITLE
Bump crucible-common to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser": "^21.2.1",
         "@angular/platform-browser-dynamic": "^21.2.1",
         "@angular/router": "^21.2.1",
-        "@cmusei/crucible-common": "0.7.2",
+        "@cmusei/crucible-common": "0.7.3",
         "@datorama/akita": "^8.0.0",
         "@datorama/akita-ng-router-store": "^7.0.0",
         "@datorama/akita-ngdevtools": "^7.0.0",
@@ -2718,9 +2718,8 @@
       }
     },
     "node_modules/@cmusei/crucible-common": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.2.tgz",
-      "integrity": "sha512-wIxhKoylCBOmh/92TrZWoZkIZyDoqATHQKXLvOafKWoyBbB4D6oM78BoFdqu5mzDnOi5qQe2R2Dt1/dDptEwvg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.3.tgz",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/platform-browser": "^21.2.1",
     "@angular/platform-browser-dynamic": "^21.2.1",
     "@angular/router": "^21.2.1",
-    "@cmusei/crucible-common": "0.7.2",
+    "@cmusei/crucible-common": "0.7.3",
     "@datorama/akita": "^8.0.0",
     "@datorama/akita-ng-router-store": "^7.0.0",
     "@datorama/akita-ngdevtools": "^7.0.0",

--- a/src/app/components/admin/admin-groups/admin-groups.component.ts
+++ b/src/app/components/admin/admin-groups/admin-groups.component.ts
@@ -97,7 +97,7 @@ export class AdminGroupsComponent implements OnInit, AfterViewInit {
   createGroup() {
     this.nameDialog('Create New Group?', '', { nameValue: '' }).subscribe(
       (result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           this.groupDataService
             .create({ name: result[NAME_VALUE] })
             .subscribe();
@@ -110,7 +110,7 @@ export class AdminGroupsComponent implements OnInit, AfterViewInit {
     this.nameDialog('Rename ' + group.name, '', {
       nameValue: group.name,
     }).subscribe((result) => {
-      if (!result.wasCancelled) {
+      if (result) {
         this.groupDataService
           .edit({ id: group.id, name: result[NAME_VALUE] })
           .subscribe();
@@ -142,6 +142,6 @@ export class AdminGroupsComponent implements OnInit, AfterViewInit {
     dialogRef.componentInstance.title = title;
     dialogRef.componentInstance.message = message;
 
-    return dialogRef.afterClosed().pipe(map(result => result ?? { wasCancelled: true }));
+    return dialogRef.afterClosed();
   }
 }

--- a/src/app/components/item-download-dialog/item-download-dialog.component.html
+++ b/src/app/components/item-download-dialog/item-download-dialog.component.html
@@ -8,7 +8,6 @@ project root for license information or contact permission@sei.cmu.edu for full 
   [dialogTitle]="data.title"
   submitLabel="Download"
   [submitDisabled]="selected.size === 0"
-  (cancel)="cancel()"
   (submit)="download()"
 >
 <div crucibleDialogContent>

--- a/src/app/components/item-download-dialog/item-download-dialog.component.ts
+++ b/src/app/components/item-download-dialog/item-download-dialog.component.ts
@@ -55,10 +55,6 @@ export class ItemDownloadDialogComponent {
     }
   }
 
-  cancel() {
-    this.dialogRef.close();
-  }
-
   download() {
     this.dialogRef.close([...this.selected]);
   }

--- a/src/app/components/shared/name-dialog/name-dialog.component.html
+++ b/src/app/components/shared/name-dialog/name-dialog.component.html
@@ -8,7 +8,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   [form]="form"
   [submitDisabled]="!form.valid || !form.dirty"
   [guardUnsavedWork]="true"
-  (cancel)="onCancel()"
   (submit)="onClick()"
 >
   <div crucibleDialogContent [formGroup]="form" class="name-form">

--- a/src/app/components/shared/name-dialog/name-dialog.component.ts
+++ b/src/app/components/shared/name-dialog/name-dialog.component.ts
@@ -50,15 +50,6 @@ export class NameDialogComponent {
       ? (this.data.removeArtifacts = this.removeArtifacts)
       : (this.data.removeArtifacts = false);
     this.data.nameValue = this.form?.get('name').value;
-    this.data.wasCancelled = false;
-    this.dialogRef.close(this.data);
-  }
-
-  onCancel(): void {
-    this.data.artifacts && this.data.artifacts.length > 0
-      ? (this.data.removeArtifacts = this.removeArtifacts)
-      : (this.data.removeArtifacts = false);
-    this.data.wasCancelled = true;
     this.dialogRef.close(this.data);
   }
 }

--- a/src/app/components/team-competency-propagate-dialog/team-competency-propagate-dialog.component.html
+++ b/src/app/components/team-competency-propagate-dialog/team-competency-propagate-dialog.component.html
@@ -10,7 +10,6 @@ project root for license information or contact permission@sei.cmu.edu for full 
   cancelLabel="No"
   [submitDisabled]="selection.isEmpty()"
   [guardUnsavedWork]="true"
-  (cancel)="onCancel()"
   (submit)="onConfirm()"
 >
 <div crucibleDialogContent>

--- a/src/app/components/team-competency-propagate-dialog/team-competency-propagate-dialog.component.ts
+++ b/src/app/components/team-competency-propagate-dialog/team-competency-propagate-dialog.component.ts
@@ -55,7 +55,4 @@ export class TeamCompetencyPropagateDialogComponent {
     this.dialogRef.close(this.selection.selected);
   }
 
-  onCancel(): void {
-    this.dialogRef.close(null);
-  }
 }


### PR DESCRIPTION
## Summary

Bumps `@cmusei/crucible-common` from `0.7.2` to `0.7.3`.

**What 0.7.3 provides:**
- **Cancel now closes `crucible-dialog` via the injected `MatDialogRef` instead of a bare `mat-dialog-close` attribute.** Previously the bare attribute made Angular close with `''` (empty string) rather than `undefined`, which slipped past `result ?? {...}` and `!result.wasCancelled` guards — a cancelled dialog could be treated as a real result.
- **Loading-state layout fix**: the primary button's label and `<mat-progress-spinner>` are now wrapped and laid out as one centered inline-flex row, fixing the spinner dropping to its own line beneath the label text while `loading` is set.

**Impact on blueprint.ui:**
- `NameDialogComponent.onCancel()` (with its `wasCancelled` payload), `ItemDownloadDialogComponent.cancel()`, and `TeamCompetencyPropagateDialogComponent.onCancel()` are all now redundant — they existed solely to close the dialog explicitly to compensate for the old `''`-on-cancel behavior — and have been removed along with their `(cancel)` bindings.
- `AdminGroupsComponent`'s `nameDialog(...)` subscription now guards with a simple truthy check (`if (result)`) instead of `if (!result.wasCancelled)`, since cancellation now reliably emits `undefined`.
- No consumer-visible behavior change other than fixing the same class of "cancel treated as submit" bug this crucible-common release targets — cancelling the group/item-download/team-competency-propagate dialogs now correctly no-ops.
