### PR TITLE
Fix memory leak in MSEL Info section

### DIFF
--- a/src/app/components/msel-info/msel-info.component.ts
+++ b/src/app/components/msel-info/msel-info.component.ts
@@ -323,9 +323,12 @@ export class MselInfoComponent implements OnDestroy, OnInit {
       }
     );
     // subscribe to data fields
-    this.dataFieldQuery.selectAll().subscribe((dataFields) => {
-      this.dataFieldList = dataFields;
-    });
+    this.dataFieldQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((dataFields) => {
+        this.dataFieldList = dataFields;
+      });
     // subscribe to scenario events
     this.scenarioEventQuery
       .selectAll()


### PR DESCRIPTION
## Problem

`MselInfoComponent`'s constructor subscribes to `dataFieldQuery.selectAll()` without
`takeUntil(this.unsubscribe$)`, unlike the six sibling store subscriptions around it.

Akita store observables never complete, so the subscription outlived the component and its
callback closure kept the destroyed component — and its entire DOM subtree — reachable.
Every render of the Info section leaked one live subscription.

`ngOnDestroy` already fires `unsubscribe$`; this subscription simply was not wired to it.

## Fix

Pipe it through `takeUntil` like its siblings. 6 insertions, 3 deletions, one file.

```ts
this.dataFieldQuery
  .selectAll()
  .pipe(takeUntil(this.unsubscribe$))
  .subscribe((dataFields) => {
    this.dataFieldList = dataFields;
  });
```

No behavior change — the subscription is still live for the component's whole lifetime. It
now just ends when the component does.